### PR TITLE
feat: apply full MVVM architecture with Hilt DI and UseCase layer

### DIFF
--- a/iBichos-app/app/build.gradle.kts
+++ b/iBichos-app/app/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
     id("com.google.gms.google-services")
+    id("com.google.dagger.hilt.android")
+    id("kotlin-kapt")
 }
 
 // Leer la API key desde local.properties de forma segura
@@ -127,4 +129,9 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0")
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.7.0")
     implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
+
+    // ── Hilt (Dependency Injection) ───────────────────────────────────────────
+    implementation("com.google.dagger:hilt-android:2.48.1")
+    kapt("com.google.dagger:hilt-android-compiler:2.48.1")
+    implementation("androidx.hilt:hilt-navigation-compose:1.1.0")
 }

--- a/iBichos-app/app/src/main/AndroidManifest.xml
+++ b/iBichos-app/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
     <uses-feature android:name="android.hardware.location.gps" android:required="false" />
 
     <application
+        android:name=".IBichosApplication"
         android:allowBackup="true"
         android:icon="@drawable/logo_oficial"
         android:label="@string/app_name"

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/IBichosApplication.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/IBichosApplication.kt
@@ -1,0 +1,7 @@
+package com.cetecom.ibichos
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class IBichosApplication : Application()

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/data/repository/AuthRepositoryImpl.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/data/repository/AuthRepositoryImpl.kt
@@ -1,0 +1,145 @@
+package com.cetecom.ibichos.data.repository
+
+import com.cetecom.ibichos.domain.repository.AuthRepository
+import com.google.firebase.Timestamp
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.GoogleAuthProvider
+import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
+
+class AuthRepositoryImpl @Inject constructor(
+    private val auth: FirebaseAuth,
+    private val db: FirebaseFirestore
+) : AuthRepository {
+
+    override fun isLoggedIn(): Boolean = auth.currentUser != null
+
+    override fun getCurrentUserId(): String? = auth.currentUser?.uid
+
+    override suspend fun login(email: String, password: String) {
+        auth.signInWithEmailAndPassword(email, password).await()
+    }
+
+    override suspend fun register(
+        email: String,
+        password: String,
+        displayName: String,
+        region: String,
+        city: String,
+        birthDate: String,
+        gender: String
+    ): String {
+        val result = auth.createUserWithEmailAndPassword(email, password).await()
+        val uid = result.user?.uid ?: throw IllegalStateException("UID nulo tras el registro")
+
+        db.collection("users").document(uid).set(
+            hashMapOf(
+                "displayName"        to displayName,
+                "email"              to email,
+                "region"             to region,
+                "city"               to city,
+                "birthDate"          to birthDate,
+                "gender"             to gender,
+                "avatarUrl"          to null,
+                "totalCaptures"      to 0,
+                "createdAt"          to Timestamp.now(),
+                "strikes"            to 0,
+                "isShadowBanned"     to false,
+                "xp"                 to 0L,
+                "uniqueInsectsCount" to 0,
+                "medalsCount"        to 0,
+                "gamification" to hashMapOf(
+                    "xp"                 to 0L,
+                    "level"              to "CASUAL",
+                    "uniqueInsectsCount" to 0,
+                    "medals"             to emptyList<String>(),
+                    "medalsEarnedAt"     to emptyMap<String, Long>(),
+                    "categoryCounts"     to emptyMap<String, Int>(),
+                    "levelUpAt"          to emptyMap<String, Long>()
+                )
+            )
+        ).await()
+
+        return uid
+    }
+
+    override suspend fun signInWithGoogle(idToken: String): Pair<String, Boolean> {
+        val credential = GoogleAuthProvider.getCredential(idToken, null)
+        val result = auth.signInWithCredential(credential).await()
+        val user = result.user ?: throw IllegalStateException("Usuario nulo tras Google Sign-In")
+        val isNewUser = result.additionalUserInfo?.isNewUser == true
+
+        if (isNewUser) {
+            db.collection("users").document(user.uid).set(
+                hashMapOf(
+                    "displayName"        to (user.displayName ?: "Cazador"),
+                    "email"              to (user.email ?: ""),
+                    "region"             to "",
+                    "city"               to "",
+                    "birthDate"          to "",
+                    "gender"             to "UNSPECIFIED",
+                    "avatarUrl"          to user.photoUrl?.toString(),
+                    "totalCaptures"      to 0,
+                    "createdAt"          to Timestamp.now(),
+                    "strikes"            to 0,
+                    "isShadowBanned"     to false,
+                    "xp"                 to 0L,
+                    "uniqueInsectsCount" to 0,
+                    "medalsCount"        to 0,
+                    "gamification"       to hashMapOf(
+                        "xp"                 to 0L,
+                        "level"              to "CASUAL",
+                        "uniqueInsectsCount" to 0,
+                        "medals"             to emptyList<String>(),
+                        "medalsEarnedAt"     to emptyMap<String, Long>(),
+                        "categoryCounts"     to emptyMap<String, Int>(),
+                        "levelUpAt"          to emptyMap<String, Long>()
+                    )
+                )
+            ).await()
+        }
+
+        return Pair(user.uid, isNewUser)
+    }
+
+    override suspend fun completeProfile(
+        uid: String,
+        region: String,
+        city: String,
+        birthDate: String,
+        gender: String
+    ) {
+        db.collection("users").document(uid).update(
+            mapOf(
+                "region"    to region,
+                "city"      to city,
+                "birthDate" to birthDate,
+                "gender"    to gender
+            )
+        ).await()
+    }
+
+    override suspend fun checkProfileCompletion(uid: String): Boolean {
+        val doc = db.collection("users").document(uid).get().await()
+        val region = doc.getString("region") ?: ""
+        val city = doc.getString("city") ?: ""
+        val birthDate = doc.getString("birthDate") ?: ""
+        return region.isNotEmpty() && city.isNotEmpty() && birthDate.isNotEmpty()
+    }
+
+    override suspend fun getLocations(): Map<String, List<String>> {
+        val doc = db.collection("metadata").document("locations").get().await()
+        if (!doc.exists()) return emptyMap()
+        @Suppress("UNCHECKED_CAST")
+        return (doc.get("regions") as? Map<String, List<String>>) ?: emptyMap()
+    }
+
+    override fun signOut() {
+        auth.signOut()
+    }
+
+    override fun sendPasswordResetEmail(email: String) {
+        auth.sendPasswordResetEmail(email)
+    }
+}

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/data/repository/CaptureRepositoryImpl.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/data/repository/CaptureRepositoryImpl.kt
@@ -8,13 +8,14 @@ import com.google.firebase.Timestamp
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.Query
 import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
 
 /**
  * Implementación de [CaptureRepository] usando Firebase Firestore.
  * La extensión .await() convierte las Tasks de Firebase en coroutines.
  */
-class CaptureRepositoryImpl(
-    private val db: FirebaseFirestore = FirebaseFirestore.getInstance()
+class CaptureRepositoryImpl @Inject constructor(
+    private val db: FirebaseFirestore
 ) : CaptureRepository {
 
     override suspend fun getCaptures(userId: String): List<CaptureItem> {

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/data/repository/EventRepositoryImpl.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/data/repository/EventRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.cetecom.ibichos.data.repository
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
 
 /**
  * Escribe eventos de gamificación en la colección Firestore `events`.
@@ -11,8 +12,8 @@ import kotlinx.coroutines.tasks.await
  * El Dashboard puede consultarla con filtros de fecha y tipo para obtener
  * métricas históricas como nivel promedio, tasa de activación de logros, etc.
  */
-class EventRepositoryImpl(
-    private val db: FirebaseFirestore = FirebaseFirestore.getInstance()
+class EventRepositoryImpl @Inject constructor(
+    private val db: FirebaseFirestore
 ) {
 
     /**

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/data/repository/SessionRepositoryImpl.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/data/repository/SessionRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.google.firebase.Timestamp
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.tasks.await
 import java.util.UUID
+import javax.inject.Inject
 
 /**
  * Implementación de [SessionRepository] usando Firebase Firestore.
@@ -18,8 +19,8 @@ import java.util.UUID
  *   deviceOS:        "Android"
  * }
  */
-class SessionRepositoryImpl(
-    private val db: FirebaseFirestore = FirebaseFirestore.getInstance()
+class SessionRepositoryImpl @Inject constructor(
+    private val db: FirebaseFirestore
 ) : SessionRepository {
 
     override suspend fun startSession(userId: String): String {

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/data/repository/UserRepositoryImpl.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/data/repository/UserRepositoryImpl.kt
@@ -1,18 +1,16 @@
 package com.cetecom.ibichos.data.repository
 
-import android.net.Uri
 import com.cetecom.ibichos.domain.model.GamificationData
 import com.cetecom.ibichos.domain.model.UserProfile
 import com.cetecom.ibichos.domain.model.enums.Gender
 import com.cetecom.ibichos.domain.model.enums.UserLevel
 import com.cetecom.ibichos.domain.repository.UserRepository
 import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.SetOptions
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.Query
-import com.google.firebase.storage.FirebaseStorage
 import kotlinx.coroutines.tasks.await
+import javax.inject.Inject
 
 /**
  * Implementación de [UserRepository] usando Firestore + Firebase Storage.
@@ -24,10 +22,9 @@ import kotlinx.coroutines.tasks.await
  *     gamification: { xp, level, uniqueInsectsCount, categoryCounts, medals, medalsEarnedAt, levelUpAt }
  *   }
  */
-class UserRepositoryImpl(
-    private val db: FirebaseFirestore = FirebaseFirestore.getInstance(),
-    private val storage: FirebaseStorage = FirebaseStorage.getInstance(),
-    private val eventRepo: EventRepositoryImpl = EventRepositoryImpl()
+class UserRepositoryImpl @Inject constructor(
+    private val db: FirebaseFirestore,
+    private val eventRepo: EventRepositoryImpl
 ) : UserRepository {
 
     override suspend fun getUserProfile(uid: String): UserProfile {
@@ -42,14 +39,11 @@ class UserRepositoryImpl(
         return mapDocumentToUserProfile(doc, captureCount = capturesResult.size())
     }
 
-    override suspend fun updateAvatar(uid: String, uri: Uri): String {
-        // Evitamos Firebase Storage para no incurrir en gastos GCP.
-        // Se guarda la URI local como String en Firestore.
-        val localUrl = uri.toString()
+    override suspend fun updateAvatar(uid: String, avatarUrl: String): String {
         db.collection("users").document(uid)
-            .update("avatarUrl", localUrl)
+            .update("avatarUrl", avatarUrl)
             .await()
-        return localUrl
+        return avatarUrl
     }
 
     override suspend fun incrementXp(uid: String, xpGain: Long) {

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/di/AppModule.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/di/AppModule.kt
@@ -1,0 +1,33 @@
+package com.cetecom.ibichos.di
+
+import com.cetecom.ibichos.data.api.KindwiseApi
+import com.cetecom.ibichos.data.repository.CloudinaryApi
+import com.cetecom.ibichos.data.repository.CloudinaryModule
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AppModule {
+
+    @Provides
+    @Singleton
+    fun provideFirebaseAuth(): FirebaseAuth = FirebaseAuth.getInstance()
+
+    @Provides
+    @Singleton
+    fun provideFirebaseFirestore(): FirebaseFirestore = FirebaseFirestore.getInstance()
+
+    @Provides
+    @Singleton
+    fun provideKindwiseApi(): KindwiseApi = KindwiseApi.create()
+
+    @Provides
+    @Singleton
+    fun provideCloudinaryApi(): CloudinaryApi = CloudinaryModule.api
+}

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/di/RepositoryModule.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/di/RepositoryModule.kt
@@ -1,0 +1,36 @@
+package com.cetecom.ibichos.di
+
+import com.cetecom.ibichos.data.repository.AuthRepositoryImpl
+import com.cetecom.ibichos.data.repository.CaptureRepositoryImpl
+import com.cetecom.ibichos.data.repository.SessionRepositoryImpl
+import com.cetecom.ibichos.data.repository.UserRepositoryImpl
+import com.cetecom.ibichos.domain.repository.AuthRepository
+import com.cetecom.ibichos.domain.repository.CaptureRepository
+import com.cetecom.ibichos.domain.repository.SessionRepository
+import com.cetecom.ibichos.domain.repository.UserRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class RepositoryModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindAuthRepository(impl: AuthRepositoryImpl): AuthRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindCaptureRepository(impl: CaptureRepositoryImpl): CaptureRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindUserRepository(impl: UserRepositoryImpl): UserRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindSessionRepository(impl: SessionRepositoryImpl): SessionRepository
+}

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/domain/repository/AuthRepository.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/domain/repository/AuthRepository.kt
@@ -1,0 +1,54 @@
+package com.cetecom.ibichos.domain.repository
+
+/**
+ * Contrato para las operaciones de autenticación y gestión de cuenta.
+ * Abstrae Firebase Auth y las escrituras iniciales en Firestore.
+ */
+interface AuthRepository {
+    fun isLoggedIn(): Boolean
+    fun getCurrentUserId(): String?
+
+    /** Inicia sesión con email/contraseña. Lanza excepción si falla. */
+    suspend fun login(email: String, password: String)
+
+    /**
+     * Registra un nuevo usuario y crea su documento en Firestore.
+     * @return uid del usuario recién creado
+     */
+    suspend fun register(
+        email: String,
+        password: String,
+        displayName: String,
+        region: String,
+        city: String,
+        birthDate: String,
+        gender: String
+    ): String
+
+    /**
+     * Autentica con Google y crea el documento de Firestore si es usuario nuevo.
+     * @return Pair(uid, isNewUser)
+     */
+    suspend fun signInWithGoogle(idToken: String): Pair<String, Boolean>
+
+    /** Completa el perfil del usuario (datos demográficos) */
+    suspend fun completeProfile(
+        uid: String,
+        region: String,
+        city: String,
+        birthDate: String,
+        gender: String
+    )
+
+    /** Verifica si el perfil del usuario tiene los campos obligatorios completos */
+    suspend fun checkProfileCompletion(uid: String): Boolean
+
+    /** Carga las regiones/ciudades desde Firestore metadata */
+    suspend fun getLocations(): Map<String, List<String>>
+
+    /** Cierra la sesión del usuario actual */
+    fun signOut()
+
+    /** Envía email de recuperación de contraseña */
+    fun sendPasswordResetEmail(email: String)
+}

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/domain/repository/UserRepository.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/domain/repository/UserRepository.kt
@@ -1,6 +1,5 @@
 package com.cetecom.ibichos.domain.repository
 
-import android.net.Uri
 import com.cetecom.ibichos.domain.model.UserProfile
 
 /**
@@ -10,8 +9,8 @@ interface UserRepository {
     /** Carga el perfil desde Firestore */
     suspend fun getUserProfile(uid: String): UserProfile
 
-    /** Sube el avatar a Firebase Storage y actualiza la URL en Firestore */
-    suspend fun updateAvatar(uid: String, uri: Uri): String
+    /** Actualiza la URL del avatar en Firestore y la devuelve */
+    suspend fun updateAvatar(uid: String, avatarUrl: String): String
 
     /** Incrementa el XP y actualiza el nivel si corresponde */
     suspend fun incrementXp(uid: String, xpGain: Long)

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/domain/usecase/auth/CompleteProfileUseCase.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/domain/usecase/auth/CompleteProfileUseCase.kt
@@ -1,0 +1,18 @@
+package com.cetecom.ibichos.domain.usecase.auth
+
+import com.cetecom.ibichos.domain.repository.AuthRepository
+import javax.inject.Inject
+
+class CompleteProfileUseCase @Inject constructor(
+    private val authRepository: AuthRepository
+) {
+    suspend operator fun invoke(
+        uid: String,
+        region: String,
+        city: String,
+        birthDate: String,
+        gender: String
+    ) {
+        authRepository.completeProfile(uid, region, city, birthDate, gender)
+    }
+}

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/domain/usecase/auth/GetLocationsUseCase.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/domain/usecase/auth/GetLocationsUseCase.kt
@@ -1,0 +1,11 @@
+package com.cetecom.ibichos.domain.usecase.auth
+
+import com.cetecom.ibichos.domain.repository.AuthRepository
+import javax.inject.Inject
+
+class GetLocationsUseCase @Inject constructor(
+    private val authRepository: AuthRepository
+) {
+    suspend operator fun invoke(): Map<String, List<String>> =
+        authRepository.getLocations()
+}

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/domain/usecase/auth/LoginUseCase.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/domain/usecase/auth/LoginUseCase.kt
@@ -1,0 +1,12 @@
+package com.cetecom.ibichos.domain.usecase.auth
+
+import com.cetecom.ibichos.domain.repository.AuthRepository
+import javax.inject.Inject
+
+class LoginUseCase @Inject constructor(
+    private val authRepository: AuthRepository
+) {
+    suspend operator fun invoke(email: String, password: String) {
+        authRepository.login(email, password)
+    }
+}

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/domain/usecase/auth/RegisterUseCase.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/domain/usecase/auth/RegisterUseCase.kt
@@ -1,0 +1,24 @@
+package com.cetecom.ibichos.domain.usecase.auth
+
+import com.cetecom.ibichos.data.repository.EventRepositoryImpl
+import com.cetecom.ibichos.domain.repository.AuthRepository
+import javax.inject.Inject
+
+class RegisterUseCase @Inject constructor(
+    private val authRepository: AuthRepository,
+    private val eventRepository: EventRepositoryImpl
+) {
+    suspend operator fun invoke(
+        email: String,
+        password: String,
+        displayName: String,
+        region: String,
+        city: String,
+        birthDate: String,
+        gender: String
+    ): String {
+        val uid = authRepository.register(email, password, displayName, region, city, birthDate, gender)
+        runCatching { eventRepository.logUserRegistered(uid) }
+        return uid
+    }
+}

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/domain/usecase/auth/SignInWithGoogleUseCase.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/domain/usecase/auth/SignInWithGoogleUseCase.kt
@@ -1,0 +1,17 @@
+package com.cetecom.ibichos.domain.usecase.auth
+
+import com.cetecom.ibichos.data.repository.EventRepositoryImpl
+import com.cetecom.ibichos.domain.repository.AuthRepository
+import javax.inject.Inject
+
+class SignInWithGoogleUseCase @Inject constructor(
+    private val authRepository: AuthRepository,
+    private val eventRepository: EventRepositoryImpl
+) {
+    /** @return uid del usuario autenticado */
+    suspend operator fun invoke(idToken: String): String {
+        val (uid, isNewUser) = authRepository.signInWithGoogle(idToken)
+        if (isNewUser) runCatching { eventRepository.logUserRegistered(uid) }
+        return uid
+    }
+}

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/domain/usecase/capture/DeleteCaptureUseCase.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/domain/usecase/capture/DeleteCaptureUseCase.kt
@@ -1,0 +1,12 @@
+package com.cetecom.ibichos.domain.usecase.capture
+
+import com.cetecom.ibichos.domain.repository.CaptureRepository
+import javax.inject.Inject
+
+class DeleteCaptureUseCase @Inject constructor(
+    private val captureRepository: CaptureRepository
+) {
+    suspend operator fun invoke(captureId: String) {
+        captureRepository.deleteCapture(captureId)
+    }
+}

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/domain/usecase/capture/GetCapturesUseCase.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/domain/usecase/capture/GetCapturesUseCase.kt
@@ -1,0 +1,12 @@
+package com.cetecom.ibichos.domain.usecase.capture
+
+import com.cetecom.ibichos.domain.model.CaptureItem
+import com.cetecom.ibichos.domain.repository.CaptureRepository
+import javax.inject.Inject
+
+class GetCapturesUseCase @Inject constructor(
+    private val captureRepository: CaptureRepository
+) {
+    suspend operator fun invoke(userId: String): List<CaptureItem> =
+        captureRepository.getCaptures(userId)
+}

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/domain/usecase/capture/ProcessCaptureUseCase.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/domain/usecase/capture/ProcessCaptureUseCase.kt
@@ -1,0 +1,105 @@
+package com.cetecom.ibichos.domain.usecase.capture
+
+import com.cetecom.ibichos.data.repository.EventRepositoryImpl
+import com.cetecom.ibichos.domain.model.enums.DangerLevel
+import com.cetecom.ibichos.domain.model.enums.GamificationConfig
+import com.cetecom.ibichos.domain.model.enums.InsectCategory
+import com.cetecom.ibichos.domain.model.enums.MedalInfo
+import com.cetecom.ibichos.domain.repository.CaptureRepository
+import com.cetecom.ibichos.domain.repository.UserRepository
+import javax.inject.Inject
+
+sealed class CaptureResult {
+    data class Success(val message: String) : CaptureResult()
+    data class LowConfidence(val probability: Double) : CaptureResult()
+}
+
+/**
+ * Orquesta la persistencia de una captura y toda la lógica de gamificación.
+ * El ViewModel es responsable de la subida a Cloudinary y la llamada a Kindwise;
+ * este UseCase recibe los datos ya procesados y aplica las reglas de negocio.
+ */
+class ProcessCaptureUseCase @Inject constructor(
+    private val captureRepository: CaptureRepository,
+    private val userRepository: UserRepository,
+    private val eventRepository: EventRepositoryImpl
+) {
+    suspend operator fun invoke(
+        uid: String,
+        imageUrl: String,
+        insectName: String,
+        scientificName: String,
+        category: InsectCategory,
+        dangerLevel: DangerLevel,
+        probability: Double,
+        lat: Double?,
+        lon: Double?,
+        description: String
+    ): CaptureResult {
+        // Reglas de moderación automática
+        if (probability < 0.40) {
+            return CaptureResult.LowConfidence(probability)
+        }
+
+        val needsReview = probability < 0.75
+        val status = if (needsReview) "PENDING_REVIEW" else "APPROVED"
+
+        val isNewInsect = !captureRepository.hasCaughtInsect(uid, scientificName)
+        val xpGain = if (isNewInsect) GamificationConfig.XP_NEW_SPECIES else GamificationConfig.XP_REPEATED_SPECIES
+
+        captureRepository.saveCapture(
+            userId       = uid,
+            imageUrl     = imageUrl,
+            insectName   = insectName,
+            scientificName = scientificName,
+            category     = category,
+            dangerLevel  = dangerLevel,
+            probability  = probability,
+            latitude     = lat,
+            longitude    = lon,
+            xpAwarded    = xpGain,
+            description  = description,
+            needsReview  = needsReview,
+            status       = status
+        )
+
+        userRepository.incrementXp(uid, xpGain)
+
+        val currentUser = userRepository.getUserProfile(uid)
+        val medalsToUnlock = GamificationConfig.evaluateMedalsToUnlock(
+            currentUser  = currentUser,
+            isNewInsect  = isNewInsect,
+            dangerLevel  = dangerLevel,
+            category     = category
+        )
+
+        if (isNewInsect) {
+            runCatching {
+                eventRepository.logSpeciesDiscovered(
+                    userId         = uid,
+                    scientificName = scientificName,
+                    insectName     = insectName,
+                    category       = category.name,
+                    xpAtEvent      = currentUser.gamification.xp + xpGain
+                )
+            }
+        }
+
+        userRepository.unlockMedalsAndIncrementUnique(
+            uid              = uid,
+            medalsToUnlock   = medalsToUnlock,
+            isNewInsect      = isNewInsect,
+            incrementCategory = category.name
+        )
+
+        val noveltyMsg = if (isNewInsect) "✨ ¡NUEVA ESPECIE DESCUBIERTA! ✨\n" else ""
+        val reviewMsg  = if (needsReview) "\n⚠️ Pendiente de verificación" else ""
+        val medalsMsg  = if (medalsToUnlock.isNotEmpty()) {
+            "\n🏅 Logros: ${medalsToUnlock.joinToString { MedalInfo.fromId(it)?.title ?: it }}"
+        } else ""
+
+        return CaptureResult.Success(
+            "${noveltyMsg}🦟 ¡Insecto Atrapado!\n$insectName\nConfianza: ${(probability * 100).toInt()}%\n🎁 +$xpGain XP$medalsMsg$reviewMsg"
+        )
+    }
+}

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/domain/usecase/map/GetMapCapturesUseCase.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/domain/usecase/map/GetMapCapturesUseCase.kt
@@ -1,0 +1,13 @@
+package com.cetecom.ibichos.domain.usecase.map
+
+import com.cetecom.ibichos.domain.model.CaptureItem
+import com.cetecom.ibichos.domain.repository.CaptureRepository
+import javax.inject.Inject
+
+class GetMapCapturesUseCase @Inject constructor(
+    private val captureRepository: CaptureRepository
+) {
+    suspend operator fun invoke(userId: String, isGlobal: Boolean): List<CaptureItem> =
+        if (isGlobal) captureRepository.getGlobalCaptures(200)
+        else captureRepository.getCaptures(userId)
+}

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/domain/usecase/profile/GetUserProfileUseCase.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/domain/usecase/profile/GetUserProfileUseCase.kt
@@ -1,0 +1,12 @@
+package com.cetecom.ibichos.domain.usecase.profile
+
+import com.cetecom.ibichos.domain.model.UserProfile
+import com.cetecom.ibichos.domain.repository.UserRepository
+import javax.inject.Inject
+
+class GetUserProfileUseCase @Inject constructor(
+    private val userRepository: UserRepository
+) {
+    suspend operator fun invoke(uid: String): UserProfile =
+        userRepository.getUserProfile(uid)
+}

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/domain/usecase/profile/UploadAvatarUseCase.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/domain/usecase/profile/UploadAvatarUseCase.kt
@@ -1,0 +1,34 @@
+package com.cetecom.ibichos.domain.usecase.profile
+
+import com.cetecom.ibichos.data.repository.CloudinaryApi
+import com.cetecom.ibichos.domain.repository.UserRepository
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.asRequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.File
+import javax.inject.Inject
+
+class UploadAvatarUseCase @Inject constructor(
+    private val cloudinaryApi: CloudinaryApi,
+    private val userRepository: UserRepository
+) {
+    private val cloudName    = "drubfka1z"
+    private val uploadPreset = "IBichos"
+
+    /** Sube [imageFile] a Cloudinary, guarda la URL en Firestore y la devuelve. */
+    suspend operator fun invoke(uid: String, imageFile: File): String {
+        val requestFile = imageFile.asRequestBody("image/*".toMediaType())
+        val filePart    = MultipartBody.Part.createFormData("file", imageFile.name, requestFile)
+        val presetBody  = uploadPreset.toRequestBody("text/plain".toMediaType())
+
+        val response = cloudinaryApi.uploadImage(
+            cloudName    = cloudName,
+            file         = filePart,
+            uploadPreset = presetBody
+        )
+
+        val url = response.secure_url ?: throw Exception("Cloudinary no devolvió una URL válida")
+        return userRepository.updateAvatar(uid, url)
+    }
+}

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/domain/usecase/ranking/GetRankingUseCase.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/domain/usecase/ranking/GetRankingUseCase.kt
@@ -1,0 +1,17 @@
+package com.cetecom.ibichos.domain.usecase.ranking
+
+import com.cetecom.ibichos.domain.model.UserProfile
+import com.cetecom.ibichos.domain.repository.UserRepository
+import com.cetecom.ibichos.presentation.ranking.RankingType
+import javax.inject.Inject
+
+class GetRankingUseCase @Inject constructor(
+    private val userRepository: UserRepository
+) {
+    suspend operator fun invoke(type: RankingType, limit: Int = 50): List<UserProfile> =
+        when (type) {
+            RankingType.XP     -> userRepository.getTopUsersByXp(limit)
+            RankingType.UNIQUE -> userRepository.getTopUsersByUniqueInsects(limit)
+            RankingType.MEDALS -> userRepository.getTopUsersByMedals(limit)
+        }
+}

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/MainActivity.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/MainActivity.kt
@@ -6,12 +6,14 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.*
 import androidx.lifecycle.lifecycleScope
-import com.cetecom.ibichos.data.repository.SessionRepositoryImpl
+import com.cetecom.ibichos.domain.repository.SessionRepository
 import com.cetecom.ibichos.presentation.navigation.AppNavigation
 import com.cetecom.ibichos.ui.theme.IBichosTheme
 import com.cetecom.ibichos.utils.ThemePreferences
 import com.google.firebase.auth.FirebaseAuth
+import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 val LocalThemePreferences = staticCompositionLocalOf<ThemePreferences> {
     error("No ThemePreferences provided")
@@ -22,9 +24,10 @@ val LocalThemePreferences = staticCompositionLocalOf<ThemePreferences> {
  * Solo monta el NavHost dentro del tema. Toda la navegación ocurre en Compose.
  * También gestiona el ciclo de vida de las AppSessions para métricas del Dashboard.
  */
+@AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
-    private val sessionRepository = SessionRepositoryImpl()
+    @Inject lateinit var sessionRepository: SessionRepository
     private val auth = FirebaseAuth.getInstance()
 
     /** ID de la sesión activa. Null si no hay sesión iniciada o el usuario no está logueado. */

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/auth/AuthViewModel.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/auth/AuthViewModel.kt
@@ -1,36 +1,41 @@
 package com.cetecom.ibichos.presentation.auth
 
+import android.app.Activity
+import androidx.activity.result.ActivityResult
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.google.firebase.Timestamp
-import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.firestore.FirebaseFirestore
+import com.cetecom.ibichos.domain.repository.AuthRepository
+import com.cetecom.ibichos.domain.usecase.auth.CompleteProfileUseCase
+import com.cetecom.ibichos.domain.usecase.auth.GetLocationsUseCase
+import com.cetecom.ibichos.domain.usecase.auth.LoginUseCase
+import com.cetecom.ibichos.domain.usecase.auth.RegisterUseCase
+import com.cetecom.ibichos.domain.usecase.auth.SignInWithGoogleUseCase
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.common.api.ApiException
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.tasks.await
-import android.app.Activity
-import androidx.activity.result.ActivityResult
-import com.google.android.gms.auth.api.signin.GoogleSignIn
-import com.google.android.gms.common.api.ApiException
-import com.google.firebase.auth.FirebaseUser
-import com.google.firebase.auth.GoogleAuthProvider
-import com.cetecom.ibichos.data.repository.EventRepositoryImpl
+import javax.inject.Inject
 
 data class AuthUiState(
     val isLoading: Boolean = false,
     val isSuccess: Boolean = false,
     val error: String? = null,
-    val user: FirebaseUser? = null
-    )
+    val userId: String? = null
+)
 
-class AuthViewModel : ViewModel() {
-
-    private val auth = FirebaseAuth.getInstance()
-    private val db   = FirebaseFirestore.getInstance()
-    private val eventRepo = EventRepositoryImpl()
+@HiltViewModel
+class AuthViewModel @Inject constructor(
+    private val authRepository: AuthRepository,
+    private val loginUseCase: LoginUseCase,
+    private val registerUseCase: RegisterUseCase,
+    private val signInWithGoogleUseCase: SignInWithGoogleUseCase,
+    private val completeProfileUseCase: CompleteProfileUseCase,
+    private val getLocationsUseCase: GetLocationsUseCase
+) : ViewModel() {
 
     private val _uiState = MutableStateFlow(AuthUiState())
     val uiState: StateFlow<AuthUiState> = _uiState.asStateFlow()
@@ -39,47 +44,34 @@ class AuthViewModel : ViewModel() {
     val locations: StateFlow<Map<String, List<String>>> = _locations.asStateFlow()
 
     init {
-        auth.addAuthStateListener { firebaseAuth ->
-            val user = firebaseAuth.currentUser
-            _uiState.update { it.copy(user = user) }
-        }
+        _uiState.update { it.copy(userId = authRepository.getCurrentUserId()) }
         loadLocations()
     }
 
     private fun loadLocations() {
         viewModelScope.launch {
-            try {
-                val doc = db.collection("metadata").document("locations").get().await()
-                if (doc.exists()) {
-                    @Suppress("UNCHECKED_CAST")
-                    val regions = doc.get("regions") as? Map<String, List<String>>
-                    if (regions != null) {
-                        _locations.value = regions
-                    }
-                }
-            } catch (e: Exception) {
-                e.printStackTrace()
-            }
+            runCatching { _locations.value = getLocationsUseCase() }
         }
     }
 
-    /** ¿Hay sesión activa? Se evalúa al arrancar la pantalla de Login */
-    fun isLoggedIn(): Boolean = auth.currentUser != null
+    fun isLoggedIn(): Boolean = authRepository.isLoggedIn()
 
     fun login(email: String, password: String) {
         if (email.isBlank() || password.isBlank()) {
             _uiState.update { it.copy(error = "Completá todos los campos") }
             return
         }
-
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
-            try {
-                auth.signInWithEmailAndPassword(email, password).await()
-                _uiState.update { it.copy(isLoading = false, isSuccess = true) }
-            } catch (e: Exception) {
-                _uiState.update { it.copy(isLoading = false, error = e.message) }
-            }
+            runCatching { loginUseCase(email, password) }
+                .onSuccess {
+                    _uiState.update { s ->
+                        s.copy(isLoading = false, isSuccess = true, userId = authRepository.getCurrentUserId())
+                    }
+                }
+                .onFailure { e ->
+                    _uiState.update { it.copy(isLoading = false, error = e.message) }
+                }
         }
     }
 
@@ -92,128 +84,53 @@ class AuthViewModel : ViewModel() {
         birthDate: String,
         gender: String
     ) {
-        if (email.isBlank() || password.isBlank() || displayName.isBlank() ||
-            region.isBlank() || city.isBlank() || birthDate.isBlank() || gender.isBlank()) {
+        if (listOf(email, password, displayName, region, city, birthDate, gender).any { it.isBlank() }) {
             _uiState.update { it.copy(error = "Completá todos los campos") }
             return
         }
-
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
-            try {
-                val result = auth.createUserWithEmailAndPassword(email, password).await()
-                val uid    = result.user?.uid ?: ""
-
-                // Crear documento con la nueva estructura (gamification como sub-mapa)
-                db.collection("users").document(uid).set(
-                    hashMapOf(
-                        // Datos del perfil
-                        "displayName"        to displayName,
-                        "email"              to email,
-                        "region"             to region,
-                        "city"               to city,
-                        "birthDate"          to birthDate,
-                        "gender"             to gender,
-                        "avatarUrl"          to null,
-                        "totalCaptures"      to 0,
-                        "createdAt"          to Timestamp.now(),
-
-                        // Moderación
-                        "strikes"            to 0,
-                        "isShadowBanned"     to false,
-
-                        // Campos raíz denormalizados para queries de ranking sin índices compuestos
-                        "xp"                 to 0L,
-                        "uniqueInsectsCount" to 0,
-                        "medalsCount"        to 0,
-
-                        // Sub-documento de gamificación
-                        "gamification" to hashMapOf(
-                            "xp"                 to 0L,
-                            "level"              to "CASUAL",
-                            "uniqueInsectsCount" to 0,
-                            "medals"             to emptyList<String>(),
-                            "medalsEarnedAt"     to emptyMap<String, Long>(),
-                            "categoryCounts"     to emptyMap<String, Int>(),
-                            "levelUpAt"          to emptyMap<String, Long>()
-                        )
-                    )
-                ).await()
-
-                _uiState.update { it.copy(isLoading = false, isSuccess = true) }
-                // 📝 Log de registro para analíticas históricas
-                runCatching { eventRepo.logUserRegistered(uid) }
-            } catch (e: Exception) {
-                _uiState.update { it.copy(isLoading = false, error = e.message) }
-            }
+            runCatching { registerUseCase(email, password, displayName, region, city, birthDate, gender) }
+                .onSuccess { uid ->
+                    _uiState.update { it.copy(isLoading = false, isSuccess = true, userId = uid) }
+                }
+                .onFailure { e ->
+                    _uiState.update { it.copy(isLoading = false, error = e.message) }
+                }
         }
     }
 
-    fun completeProfile(
-        region: String,
-        city: String,
-        birthDate: String,
-        gender: String
-    ) {
-        val uid = auth.currentUser?.uid ?: return
-        if (region.isBlank() || city.isBlank() || birthDate.isBlank() || gender.isBlank()) {
+    fun completeProfile(region: String, city: String, birthDate: String, gender: String) {
+        val uid = authRepository.getCurrentUserId() ?: return
+        if (listOf(region, city, birthDate, gender).any { it.isBlank() }) {
             _uiState.update { it.copy(error = "Completá todos los campos") }
             return
         }
-
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
-            try {
-                db.collection("users").document(uid).update(
-                    mapOf(
-                        "region"    to region,
-                        "city"      to city,
-                        "birthDate" to birthDate,
-                        "gender"    to gender
-                    )
-                ).await()
-                _uiState.update { it.copy(isLoading = false, isSuccess = true) }
-            } catch (e: Exception) {
-                _uiState.update { it.copy(isLoading = false, error = e.message) }
-            }
+            runCatching { completeProfileUseCase(uid, region, city, birthDate, gender) }
+                .onSuccess { _uiState.update { it.copy(isLoading = false, isSuccess = true) } }
+                .onFailure { e -> _uiState.update { it.copy(isLoading = false, error = e.message) } }
         }
     }
 
     fun checkProfileCompletion(onResult: (Boolean) -> Unit) {
-        val uid = auth.currentUser?.uid ?: return onResult(false)
+        val uid = authRepository.getCurrentUserId() ?: return onResult(false)
         viewModelScope.launch {
-            try {
-                val doc = db.collection("users").document(uid).get().await()
-                val region = doc.getString("region") ?: ""
-                val city = doc.getString("city") ?: ""
-                val birthDate = doc.getString("birthDate") ?: ""
-                onResult(region.isNotEmpty() && city.isNotEmpty() && birthDate.isNotEmpty())
-            } catch (e: Exception) {
-                onResult(false)
-            }
+            onResult(runCatching { authRepository.checkProfileCompletion(uid) }.getOrDefault(false))
         }
     }
-
-    fun clearError() = _uiState.update { it.copy(error = null) }
-    fun resetSuccess() = _uiState.update { it.copy(isSuccess = false) }
-
 
     fun handleGoogleResult(result: ActivityResult) {
         if (result.resultCode != Activity.RESULT_OK) {
             setError("Inicio de sesión cancelado")
             return
         }
-
         try {
-            val task = GoogleSignIn.getSignedInAccountFromIntent(result.data)
+            val task    = GoogleSignIn.getSignedInAccountFromIntent(result.data)
             val account = task.getResult(ApiException::class.java)
-            val idToken = account.idToken
-
-            if (idToken != null) {
-                signInWithGoogle(idToken)
-            } else {
-                setError("No se pudo obtener la identidad de Google")
-            }
+            val idToken = account.idToken ?: run { setError("No se pudo obtener la identidad de Google"); return }
+            signInWithGoogle(idToken)
         } catch (e: Exception) {
             setError("Error al conectar con Google")
         }
@@ -221,83 +138,27 @@ class AuthViewModel : ViewModel() {
 
     private fun signInWithGoogle(idToken: String) {
         viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(isLoading = true, error = null)
-
-            try {
-                val credential = GoogleAuthProvider.getCredential(idToken, null)
-                val result = auth.signInWithCredential(credential).await()
-                val user = result.user
-
-                // Crear documento en Firestore solo si es un usuario NUEVO con Google
-                if (result.additionalUserInfo?.isNewUser == true && user != null) {
-                    db.collection("users").document(user.uid).set(
-                        hashMapOf(
-                            "displayName"        to (user.displayName ?: "Cazador"),
-                            "email"              to (user.email ?: ""),
-                            "region"             to "",
-                            "city"               to "",
-                            "birthDate"          to "",
-                            "gender"             to "UNSPECIFIED",
-                            "avatarUrl"          to user.photoUrl?.toString(),
-                            "totalCaptures"      to 0,
-                            "createdAt"          to Timestamp.now(),
-                            "strikes"            to 0,
-                            "isShadowBanned"     to false,
-                            "xp"                 to 0L,
-                            "uniqueInsectsCount" to 0,
-                            "medalsCount"        to 0,
-                            "gamification"       to hashMapOf(
-                                "xp"                 to 0L,
-                                "level"              to "CASUAL",
-                                "uniqueInsectsCount" to 0,
-                                "medals"             to emptyList<String>(),
-                                "medalsEarnedAt"     to emptyMap<String, Long>(),
-                                "categoryCounts"     to emptyMap<String, Int>(),
-                                "levelUpAt"          to emptyMap<String, Long>()
-                            )
-                        )
-                    ).await()
+            _uiState.update { it.copy(isLoading = true, error = null) }
+            runCatching { signInWithGoogleUseCase(idToken) }
+                .onSuccess { uid ->
+                    _uiState.update { it.copy(isLoading = false, isSuccess = true, userId = uid) }
                 }
-
-                _uiState.value = AuthUiState(
-                    isLoading = false,
-                    user = result.user,
-                    error = null
-                )
-                // 📝 Log de registro para nuevos usuarios de Google
-                if (result.additionalUserInfo?.isNewUser == true && user != null) {
-                    runCatching { eventRepo.logUserRegistered(user.uid) }
+                .onFailure { e ->
+                    _uiState.update { it.copy(isLoading = false, error = e.message ?: "Error Firebase") }
                 }
-            } catch (e: Exception) {
-                _uiState.value = _uiState.value.copy(
-                    isLoading = false,
-                    error = e.message ?: "Error Firebase"
-                )
-            }
         }
     }
 
     fun signOut() {
-        auth.signOut()
+        authRepository.signOut()
         _uiState.value = AuthUiState()
     }
 
-    fun setError(message: String) {
-        _uiState.value = _uiState.value.copy(error = message)
-    }
-
-
     fun resetPassword(email: String) {
-        FirebaseAuth.getInstance()
-            .sendPasswordResetEmail(email)
-            .addOnCompleteListener { task ->
-                if (task.isSuccessful) {
-                    // correo enviado
-                } else {
-                    // error
-                }
-            }
+        authRepository.sendPasswordResetEmail(email)
     }
+
+    fun setError(message: String) = _uiState.update { it.copy(error = message) }
+    fun clearError()              = _uiState.update { it.copy(error = null) }
+    fun resetSuccess()            = _uiState.update { it.copy(isSuccess = false) }
 }
-
-

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/auth/CompleteProfileScreen.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/auth/CompleteProfileScreen.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.cetecom.ibichos.R
 import com.cetecom.ibichos.domain.model.ChileanData
 import com.cetecom.ibichos.ui.theme.*
@@ -33,7 +33,7 @@ import java.util.Locale
 @Composable
 fun CompleteProfileScreen(
     onSuccess: () -> Unit,
-    viewModel: AuthViewModel = viewModel()
+    viewModel: AuthViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/auth/LoginScreen.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/auth/LoginScreen.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.cetecom.ibichos.R
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInOptions
@@ -46,7 +46,7 @@ import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 fun LoginScreen(
     onLoginSuccess: () -> Unit,
     onNavigateToRegister: () -> Unit,
-    viewModel: AuthViewModel = viewModel()
+    viewModel: AuthViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
@@ -75,8 +75,8 @@ fun LoginScreen(
         viewModel.handleGoogleResult(it)
     }
 
-    LaunchedEffect(uiState.user) {
-        if (uiState.user != null) onLoginSuccess()
+    LaunchedEffect(uiState.userId) {
+        if (uiState.userId != null) onLoginSuccess()
     }
 
     val backgroundGradient = Brush.verticalGradient(

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/auth/RegisterScreen.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/auth/RegisterScreen.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.cetecom.ibichos.R
 import com.cetecom.ibichos.domain.model.ChileanData
 import com.cetecom.ibichos.ui.theme.*
@@ -46,7 +46,7 @@ private val SoftGreen = Color(0xFFEAF8EF)
 fun RegisterScreen(
     onRegisterSuccess: () -> Unit,
     onNavigateBack: () -> Unit,
-    viewModel: AuthViewModel = viewModel()
+    viewModel: AuthViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/camera/CameraScreen.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/camera/CameraScreen.kt
@@ -38,7 +38,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.cetecom.ibichos.ui.theme.*
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.Priority
@@ -59,7 +59,7 @@ fun isGpsEnabled(context: Context): Boolean {
 }
 
 @Composable
-fun CameraScreen(viewModel: CameraViewModel = viewModel()) {
+fun CameraScreen(viewModel: CameraViewModel = hiltViewModel()) {
     val context        = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
     val uiState        by viewModel.uiState.collectAsStateWithLifecycle()

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/camera/CameraViewModel.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/camera/CameraViewModel.kt
@@ -8,15 +8,13 @@ import androidx.lifecycle.viewModelScope
 import com.cetecom.ibichos.BuildConfig
 import com.cetecom.ibichos.data.api.KindwiseApi
 import com.cetecom.ibichos.data.api.KindwiseRequest
-import com.cetecom.ibichos.data.repository.CaptureRepositoryImpl
-import com.cetecom.ibichos.data.repository.CloudinaryModule
-import com.cetecom.ibichos.data.repository.EventRepositoryImpl
-import com.cetecom.ibichos.data.repository.UserRepositoryImpl
+import com.cetecom.ibichos.data.repository.CloudinaryApi
 import com.cetecom.ibichos.domain.model.enums.DangerLevel
 import com.cetecom.ibichos.domain.model.enums.InsectCategory
-import com.cetecom.ibichos.domain.model.enums.GamificationConfig
-import com.cetecom.ibichos.domain.model.enums.MedalInfo
-import com.google.firebase.auth.FirebaseAuth
+import com.cetecom.ibichos.domain.repository.AuthRepository
+import com.cetecom.ibichos.domain.usecase.capture.CaptureResult
+import com.cetecom.ibichos.domain.usecase.capture.ProcessCaptureUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -29,6 +27,7 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.FileOutputStream
 import java.util.UUID
+import javax.inject.Inject
 
 sealed interface CameraUiState {
     object Idle : CameraUiState
@@ -38,293 +37,119 @@ sealed interface CameraUiState {
     data class Error(val message: String) : CameraUiState
 }
 
-class CameraViewModel : ViewModel() {
+@HiltViewModel
+class CameraViewModel @Inject constructor(
+    private val authRepository: AuthRepository,
+    private val kindwiseApi: KindwiseApi,
+    private val cloudinaryApi: CloudinaryApi,
+    private val processCaptureUseCase: ProcessCaptureUseCase
+) : ViewModel() {
 
-    private val auth = FirebaseAuth.getInstance()
-    private val captureRepository = CaptureRepositoryImpl()
-    private val userRepository = UserRepositoryImpl()
-    private val eventRepository = EventRepositoryImpl()
-    private val api = KindwiseApi.create()
-
-    // Cloudinary
-    private val cloudName = "drubfka1z"
+    private val cloudName    = "drubfka1z"
     private val uploadPreset = "IBichos"
-
-    // ── MODO EMULADOR ─────────────────────────────────────────────────────────
-    private val isEmulatorMode = false
-    // ─────────────────────────────────────────────────────────────────────────
 
     private val _uiState = MutableStateFlow<CameraUiState>(CameraUiState.Idle)
     val uiState: StateFlow<CameraUiState> = _uiState.asStateFlow()
 
-    fun setLoading() {
-        _uiState.value = CameraUiState.Loading
-    }
-
-    fun setPreview(bitmap: Bitmap, lat: Double?, lon: Double?) {
-        _uiState.value = CameraUiState.Preview(bitmap, lat, lon)
-    }
-
-    fun setError(message: String) {
-        _uiState.value = CameraUiState.Error(message)
-    }
+    fun setLoading()  { _uiState.value = CameraUiState.Loading }
+    fun setPreview(bitmap: Bitmap, lat: Double?, lon: Double?) { _uiState.value = CameraUiState.Preview(bitmap, lat, lon) }
+    fun setError(message: String)  { _uiState.value = CameraUiState.Error(message) }
+    fun resetState()  { _uiState.value = CameraUiState.Idle }
 
     fun processCapture(bitmap: Bitmap, lat: Double?, lon: Double?, context: Context) {
-        val uid = auth.currentUser?.uid ?: run {
+        val uid = authRepository.getCurrentUserId() ?: run {
             _uiState.value = CameraUiState.Error("No hay usuario autenticado")
             return
         }
 
         viewModelScope.launch {
             _uiState.value = CameraUiState.Loading
-
-            try {
-                // 1. Guardar imagen temporalmente en archivo
-                val filename = UUID.randomUUID().toString() + ".jpg"
-                val file = File(context.cacheDir, filename)
-
-                FileOutputStream(file).use { fos ->
-                    bitmap.compress(Bitmap.CompressFormat.JPEG, 70, fos)
-                    fos.flush()
-                }
-
-                if (isEmulatorMode) {
-                    saveCaptureData(
-                        uid = uid,
-                        imageUrl = "https://res.cloudinary.com/demo/image/upload/v1312461204/sample.jpg", // URL falsa de prueba
-                        insectName = "ABEJA",
-                        scientificName = "Apis mellifera",
-                        category = InsectCategory.HYMENOPTERA,
-                        dangerLevel = DangerLevel.CAUTION,
-                        probability = 0.99,
-                        lat = lat,
-                        lon = lon,
-                        description = "La abeja europea (Apis mellifera) es una especie de himenóptero apócrito de la familia Apidae. Es la especie de abeja con mayor distribución en el mundo. Son insectos polinizadores cruciales para la supervivencia de ecosistemas y para la polinización cruzada de la agricultura mundial."
-                    )
-                } else {
-                    // 2. Subir archivo a Cloudinary
-                    val requestFile = file.asRequestBody("image/*".toMediaType())
-
-                    val filePart = MultipartBody.Part.createFormData(
-                        "file",
-                        file.name,
-                        requestFile
-                    )
-
-                    val presetBody = uploadPreset.toRequestBody("text/plain".toMediaType())
-
-                    val cloudinaryResponse = CloudinaryModule.api.uploadImage(
-                        cloudName = cloudName,
-                        file = filePart,
-                        uploadPreset = presetBody
-                    )
-
-                    val cloudinaryImageUrl = cloudinaryResponse.secure_url
-                        ?: throw Exception("Cloudinary no devolvió una URL válida")
-
-                    // 3. Convertir bitmap a Base64 para Kindwise
-                    val baos = ByteArrayOutputStream()
-                    bitmap.compress(Bitmap.CompressFormat.JPEG, 70, baos)
-                    val base64 = Base64.encodeToString(baos.toByteArray(), Base64.NO_WRAP)
-
-                    // 4. Identificar insecto
-                    val response = api.identifyInsect(
-                        apiKey = BuildConfig.KINDWISE_API_KEY,
-                        request = KindwiseRequest(
-                            images = listOf("data:image/jpeg;base64,$base64"),
-                            latitude = lat,
-                            longitude = lon
-                        )
-                    )
-
-                    val suggestion = response.result?.classification?.suggestions?.firstOrNull()
-                    if (suggestion == null) {
-                        _uiState.value = CameraUiState.Error(
-                            "No se identificó ningún insecto. Intenta con otra imagen."
-                        )
-                        return@launch
-                    }
-
-                    val scientificName = suggestion.name ?: "Desconocido"
-                    val commonName = suggestion.details?.common_names?.firstOrNull() ?: ""
-                    val displayName = if (commonName.isNotEmpty()) {
-                        commonName.uppercase()
-                    } else {
-                        scientificName.uppercase()
-                    }
-                    val prob = suggestion.probability ?: 0.0
-                    val description =
-                        suggestion.details?.description?.value
-                            ?: "Insecto registrado taxonómicamente por la IA Kindwise. Se recomienda realizar un cruce de datos con enciclopedias especializadas para confirmar hábitos alimenticios y zona biológica nativa. Mantener respeto por el ecosistema local."
-
-                    // 5. Determinar categoría taxonómica desde el nombre científico
-                    //    (En el futuro se puede usar el campo 'taxon' de la respuesta de Kindwise)
-                    val category = inferCategoryFromName(scientificName)
-
-                    // 6. Peligro: Matriz de riesgo real basada en categoría taxonómica
-                    val dangerLevel = when (category) {
-                        InsectCategory.ARACHNID -> DangerLevel.VENOMOUS // Arañas/Escorpiones
-                        InsectCategory.LEPIDOPTERA -> DangerLevel.HARMLESS // Mariposas
-                        InsectCategory.COLEOPTERA -> DangerLevel.HARMLESS // Escarabajos
-                        InsectCategory.HYMENOPTERA -> DangerLevel.CAUTION  // Abejas/Avispas/Hormigas
-                        else -> DangerLevel.UNKNOWN
-                    }
-
-                    saveCaptureData(
-                        uid = uid,
-                        imageUrl = cloudinaryImageUrl,
-                        insectName = displayName,
-                        scientificName = scientificName,
-                        category = category,
-                        dangerLevel = dangerLevel,
-                        probability = prob,
-                        lat = lat,
-                        lon = lon,
-                        description = description
-                    )
-                }
-
-            } catch (e: Exception) {
-                _uiState.value = CameraUiState.Error("Error: ${e.message}")
-            }
-        }
-    }
-
-    private suspend fun saveCaptureData(
-        uid: String,
-        imageUrl: String,
-        insectName: String,
-        scientificName: String,
-        category: InsectCategory,
-        dangerLevel: DangerLevel,
-        probability: Double,
-        lat: Double?,
-        lon: Double?,
-        description: String
-    ) {
-        // ── Moderación automática ─────────────────────────────────────────────
-        // Si la IA tiene < 40% de certeza: rechazar y sumar strike
-        // Si tiene entre 40% y 75%: aceptar pero marcar para revisión humana
-        // Si tiene >= 75%: aprobar automáticamente
-        val needsReview: Boolean
-        val status: String
-
-        // Calcular UNA sola vez antes de guardar nada
-        val isNewInsect = !captureRepository.hasCaughtInsect(uid, scientificName)
-        val xpGain = if (isNewInsect) GamificationConfig.XP_NEW_SPECIES else GamificationConfig.XP_REPEATED_SPECIES
-
-        when {
-            probability < 0.40 -> {
-                // Rechazada: no dar XP
-                _uiState.value = CameraUiState.Error(
-                    "🔍 La IA no pudo identificar un insecto con suficiente certeza (${(probability * 100).toInt()}%). Intenta con otra foto con mejor iluminación."
-                )
-                return
-            }
-            probability < 0.75 -> {
-                // Aceptada pero pendiente de revisión humana
-                needsReview = true
-                status = "PENDING_REVIEW"
-            }
-            else -> {
-                // Aprobada automáticamente
-                needsReview = false
-                status = "APPROVED"
-            }
-        }
-
-        captureRepository.saveCapture(
-            userId = uid,
-            imageUrl = imageUrl,
-            insectName = insectName,
-            scientificName = scientificName,
-            category = category,
-            dangerLevel = dangerLevel,
-            probability = probability,
-            latitude = lat,
-            longitude = lon,
-            xpAwarded = xpGain,
-            description = description,
-            needsReview = needsReview,
-            status = status
-        )
-
-        // No dar XP si el usuario está shadowbanned (se verifica en incrementXp del repositorio)
-        userRepository.incrementXp(uid, xpGain)
-
-        // ── Calcular medallas (Lógica centralizada en GamificationConfig) ───
-        val currentUser = userRepository.getUserProfile(uid)
-        val medalsToUnlock = GamificationConfig.evaluateMedalsToUnlock(
-            currentUser = currentUser,
-            isNewInsect = isNewInsect,
-            dangerLevel = dangerLevel,
-            category = category
-        )
-
-        // 📝 Log completo de SPECIES_DISCOVERED con nombre (antes de unlockMedals)
-        if (isNewInsect) {
             runCatching {
-                eventRepository.logSpeciesDiscovered(
-                    userId = uid,
+                // 1. Guardar bitmap en archivo temporal
+                val file = File(context.cacheDir, "${UUID.randomUUID()}.jpg")
+                FileOutputStream(file).use { bitmap.compress(Bitmap.CompressFormat.JPEG, 70, it) }
+
+                // 2. Subir a Cloudinary
+                val filePart   = MultipartBody.Part.createFormData("file", file.name, file.asRequestBody("image/*".toMediaType()))
+                val presetBody = uploadPreset.toRequestBody("text/plain".toMediaType())
+                val imageUrl   = cloudinaryApi.uploadImage(cloudName, filePart, presetBody).secure_url
+                    ?: throw Exception("Cloudinary no devolvió una URL válida")
+
+                // 3. Codificar bitmap a Base64 para Kindwise
+                val baos   = ByteArrayOutputStream()
+                bitmap.compress(Bitmap.CompressFormat.JPEG, 70, baos)
+                val base64 = Base64.encodeToString(baos.toByteArray(), Base64.NO_WRAP)
+
+                // 4. Identificar insecto con Kindwise
+                val response   = kindwiseApi.identifyInsect(
+                    apiKey  = BuildConfig.KINDWISE_API_KEY,
+                    request = KindwiseRequest(listOf("data:image/jpeg;base64,$base64"), lat, lon)
+                )
+                val suggestion = response.result?.classification?.suggestions?.firstOrNull()
+                    ?: throw Exception("No se identificó ningún insecto. Intenta con otra imagen.")
+
+                val scientificName = suggestion.name ?: "Desconocido"
+                val commonName     = suggestion.details?.common_names?.firstOrNull() ?: ""
+                val displayName    = if (commonName.isNotEmpty()) commonName.uppercase() else scientificName.uppercase()
+                val probability    = suggestion.probability ?: 0.0
+                val description    = suggestion.details?.description?.value
+                    ?: "Insecto registrado taxonómicamente por la IA Kindwise."
+
+                val category    = inferCategoryFromName(scientificName)
+                val dangerLevel = inferDangerLevel(category)
+
+                // 5. Delegar lógica de negocio al UseCase
+                processCaptureUseCase(
+                    uid            = uid,
+                    imageUrl       = imageUrl,
+                    insectName     = displayName,
                     scientificName = scientificName,
-                    insectName = insectName,
-                    category = category.name,
-                    xpAtEvent = currentUser.gamification.xp + xpGain
+                    category       = category,
+                    dangerLevel    = dangerLevel,
+                    probability    = probability,
+                    lat            = lat,
+                    lon            = lon,
+                    description    = description
                 )
             }
+                .onSuccess { result ->
+                    _uiState.value = when (result) {
+                        is CaptureResult.Success ->
+                            CameraUiState.Success(result.message)
+                        is CaptureResult.LowConfidence ->
+                            CameraUiState.Error(
+                                "🔍 La IA no pudo identificar un insecto con suficiente certeza " +
+                                "(${(result.probability * 100).toInt()}%). Intenta con otra foto con mejor iluminación."
+                            )
+                    }
+                }
+                .onFailure { e ->
+                    _uiState.value = CameraUiState.Error("Error: ${e.message}")
+                }
         }
-
-        userRepository.unlockMedalsAndIncrementUnique(
-            uid,
-            medalsToUnlock,
-            isNewInsect,
-            category.name  // Ahora siempre es el nombre del enum en inglés (ej: "ARACHNID")
-        )
-
-        // ── Mensaje de éxito ──────────────────────────────────────────────────
-        val noveltyMsg = if (isNewInsect) "✨ ¡NUEVA ESPECIE DESCUBIERTA! ✨\n" else ""
-        val reviewMsg  = if (needsReview) "\n⚠️ Pendiente de verificación" else ""
-        val medalsMsg  = if (medalsToUnlock.isNotEmpty()) {
-            "\n🏅 Logros: ${medalsToUnlock.joinToString { MedalInfo.fromId(it)?.title ?: it }}"
-        } else ""
-
-        _uiState.value = CameraUiState.Success(
-            "${noveltyMsg}🦟 ¡Insecto Atrapado!\n$insectName\nConfianza: ${(probability * 100).toInt()}%\n🎁 +$xpGain XP$medalsMsg$reviewMsg"
-        )
     }
 
-    /**
-     * Infiere la categoría del insecto a partir de su nombre científico.
-     * En el futuro se puede usar el campo 'taxon.order' de la respuesta de Kindwise.
-     */
     private fun inferCategoryFromName(scientificName: String): InsectCategory {
         val lower = scientificName.lowercase()
         return when {
-            // Órdenes de arácnidos (no insectos, pero incluidos en el scope de la app)
-            lower.contains("araneae") || lower.contains("latrodectus") ||
-            lower.contains("loxosceles") || lower.contains("scorpion") -> InsectCategory.ARACHNID
-
-            // Coleoptera
-            lower.contains("coleoptera") || lower.contains("coccinella") ||
-            lower.contains("carabus") || lower.contains("dynastes") -> InsectCategory.COLEOPTERA
-
-            // Lepidoptera
-            lower.contains("lepidoptera") || lower.contains("papilio") ||
-            lower.contains("danaus") || lower.contains("morpho") -> InsectCategory.LEPIDOPTERA
-
-            // Hymenoptera (abejas, avispas, hormigas)
-            lower.contains("hymenoptera") || lower.contains("apis") ||
-            lower.contains("bombus") || lower.contains("vespula") ||
-            lower.contains("formica") -> InsectCategory.HYMENOPTERA
-
+            lower.contains("araneae")     || lower.contains("latrodectus") ||
+            lower.contains("loxosceles") || lower.contains("scorpion")    -> InsectCategory.ARACHNID
+            lower.contains("coleoptera") || lower.contains("coccinella")  ||
+            lower.contains("carabus")    || lower.contains("dynastes")    -> InsectCategory.COLEOPTERA
+            lower.contains("lepidoptera")|| lower.contains("papilio")     ||
+            lower.contains("danaus")     || lower.contains("morpho")      -> InsectCategory.LEPIDOPTERA
+            lower.contains("hymenoptera")|| lower.contains("apis")        ||
+            lower.contains("bombus")     || lower.contains("vespula")     ||
+            lower.contains("formica")                                      -> InsectCategory.HYMENOPTERA
             else -> InsectCategory.OTHER
         }
     }
 
-    /** Traduce el ID de medalla a nombre para mostrar en la UI. */
-    private fun medalDisplayName(medalId: String): String = MedalInfo.fromId(medalId)?.title ?: medalId
-
-    fun resetState() {
-        _uiState.value = CameraUiState.Idle
+    private fun inferDangerLevel(category: InsectCategory): DangerLevel = when (category) {
+        InsectCategory.ARACHNID    -> DangerLevel.VENOMOUS
+        InsectCategory.LEPIDOPTERA -> DangerLevel.HARMLESS
+        InsectCategory.COLEOPTERA  -> DangerLevel.HARMLESS
+        InsectCategory.HYMENOPTERA -> DangerLevel.CAUTION
+        else                       -> DangerLevel.UNKNOWN
     }
 }

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/catalog/CatalogViewModel.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/catalog/CatalogViewModel.kt
@@ -2,14 +2,18 @@ package com.cetecom.ibichos.presentation.catalog
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.cetecom.ibichos.data.repository.CaptureRepositoryImpl
 import com.cetecom.ibichos.domain.model.CaptureItem
-import com.google.firebase.auth.FirebaseAuth
+import com.cetecom.ibichos.domain.repository.AuthRepository
+import com.cetecom.ibichos.domain.repository.CaptureRepository
+import com.cetecom.ibichos.domain.usecase.capture.DeleteCaptureUseCase
+import com.cetecom.ibichos.domain.usecase.capture.GetCapturesUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 data class CatalogUiState(
     val captures: List<CaptureItem> = emptyList(),
@@ -17,10 +21,13 @@ data class CatalogUiState(
     val error: String? = null
 )
 
-class CatalogViewModel : ViewModel() {
-
-    private val auth       = FirebaseAuth.getInstance()
-    private val repository = CaptureRepositoryImpl()
+@HiltViewModel
+class CatalogViewModel @Inject constructor(
+    private val authRepository: AuthRepository,
+    private val captureRepository: CaptureRepository,
+    private val getCapturesUseCase: GetCapturesUseCase,
+    private val deleteCaptureUseCase: DeleteCaptureUseCase
+) : ViewModel() {
 
     private val _uiState = MutableStateFlow(CatalogUiState())
     val uiState: StateFlow<CatalogUiState> = _uiState.asStateFlow()
@@ -30,29 +37,36 @@ class CatalogViewModel : ViewModel() {
     }
 
     fun loadCaptures() {
-        val uid = auth.currentUser?.uid ?: return
-
+        val uid = authRepository.getCurrentUserId() ?: return
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
-            try {
-                val captures = repository.getCaptures(uid)
-                _uiState.update { it.copy(captures = captures, isLoading = false) }
-            } catch (e: Exception) {
-                _uiState.update {
-                    it.copy(isLoading = false, error = "Error al cargar capturas: ${e.message}")
+            runCatching { getCapturesUseCase(uid) }
+                .onSuccess { captures ->
+                    _uiState.update { it.copy(captures = captures, isLoading = false) }
                 }
-            }
+                .onFailure { e ->
+                    _uiState.update { it.copy(isLoading = false, error = "Error al cargar capturas: ${e.message}") }
+                }
         }
     }
 
     fun deleteCapture(id: String) {
         viewModelScope.launch {
-            try {
-                repository.deleteCapture(id)
-                loadCaptures() // Refrescar lista local
-            } catch (e: Exception) {
-                _uiState.update { it.copy(error = "No se pudo eliminar: ${e.message}") }
-            }
+            runCatching { deleteCaptureUseCase(id) }
+                .onSuccess { loadCaptures() }
+                .onFailure { e ->
+                    _uiState.update { it.copy(error = "No se pudo eliminar: ${e.message}") }
+                }
+        }
+    }
+
+    fun appealCapture(id: String) {
+        viewModelScope.launch {
+            runCatching { captureRepository.appealCapture(id) }
+                .onSuccess { loadCaptures() }
+                .onFailure { e ->
+                    _uiState.update { it.copy(error = "No se pudo apelar: ${e.message}") }
+                }
         }
     }
 }

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/map/MapScreen.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/map/MapScreen.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.compose.ui.platform.LocalLifecycleOwner
@@ -39,13 +39,14 @@ fun MapScreen(
     onNavigateToDetail: (CaptureItem) -> Unit = {},
     initialLat: Double? = null,
     initialLng: Double? = null,
-    viewModel: MapViewModel = viewModel()
+    viewModel: MapViewModel = hiltViewModel()
 ) {
     var hasCentered by remember { mutableStateOf(false) }
     val context  = LocalContext.current
-    val captures by viewModel.captures.collectAsStateWithLifecycle()
-    val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
-    val isGlobalMap by viewModel.isGlobalMap.collectAsStateWithLifecycle()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val captures  = uiState.captures
+    val isLoading = uiState.isLoading
+    val isGlobalMap = uiState.isGlobalMap
     // Referencias para que el botón pueda mover el mapa
     var mapViewRef by remember { mutableStateOf<MapView?>(null) }
     var locationOverlayRef by remember { mutableStateOf<MyLocationNewOverlay?>(null) }

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/map/MapViewModel.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/map/MapViewModel.kt
@@ -2,55 +2,54 @@ package com.cetecom.ibichos.presentation.map
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.cetecom.ibichos.data.repository.CaptureRepositoryImpl
 import com.cetecom.ibichos.domain.model.CaptureItem
-import com.google.firebase.auth.FirebaseAuth
+import com.cetecom.ibichos.domain.repository.AuthRepository
+import com.cetecom.ibichos.domain.usecase.map.GetMapCapturesUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-class MapViewModel : ViewModel() {
+data class MapUiState(
+    val captures: List<CaptureItem> = emptyList(),
+    val isLoading: Boolean = false,
+    val isGlobalMap: Boolean = false,
+    val error: String? = null
+)
 
-    private val auth       = FirebaseAuth.getInstance()
-    private val repository = CaptureRepositoryImpl()
+@HiltViewModel
+class MapViewModel @Inject constructor(
+    private val authRepository: AuthRepository,
+    private val getMapCapturesUseCase: GetMapCapturesUseCase
+) : ViewModel() {
 
-    private val _captures = MutableStateFlow<List<CaptureItem>>(emptyList())
-    val captures: StateFlow<List<CaptureItem>> = _captures.asStateFlow()
-
-    private val _isLoading = MutableStateFlow(false)
-    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
-
-    private val _isGlobalMap = MutableStateFlow(false)
-    val isGlobalMap: StateFlow<Boolean> = _isGlobalMap.asStateFlow()
+    private val _uiState = MutableStateFlow(MapUiState())
+    val uiState: StateFlow<MapUiState> = _uiState.asStateFlow()
 
     init {
         loadCaptures()
     }
 
     fun setGlobalMode(isGlobal: Boolean) {
-        if (_isGlobalMap.value == isGlobal) return
-        _isGlobalMap.value = isGlobal
+        if (_uiState.value.isGlobalMap == isGlobal) return
+        _uiState.update { it.copy(isGlobalMap = isGlobal) }
         loadCaptures()
     }
 
     fun loadCaptures() {
-        val uid = auth.currentUser?.uid ?: return
-
+        val uid = authRepository.getCurrentUserId() ?: return
         viewModelScope.launch {
-            _isLoading.value = true
-            try {
-                if (_isGlobalMap.value) {
-                    _captures.value = repository.getGlobalCaptures(200)
-                } else {
-                    _captures.value = repository.getCaptures(uid)
+            _uiState.update { it.copy(isLoading = true, error = null) }
+            runCatching { getMapCapturesUseCase(uid, _uiState.value.isGlobalMap) }
+                .onSuccess { captures ->
+                    _uiState.update { it.copy(captures = captures, isLoading = false) }
                 }
-            } catch (e: Exception) {
-                // Silencioso — el mapa simplemente no muestra pines
-            } finally {
-                _isLoading.value = false
-            }
+                .onFailure {
+                    _uiState.update { it.copy(isLoading = false) }
+                }
         }
     }
 }
-

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/navigation/AppNavigation.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/navigation/AppNavigation.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavType
 import androidx.navigation.compose.*
 import androidx.navigation.navArgument
@@ -65,7 +65,7 @@ private val bottomNavItems = listOf(
 fun AppNavigation() {
 
     val navController = rememberNavController()
-    val authViewModel: AuthViewModel = viewModel()
+    val authViewModel: AuthViewModel = hiltViewModel()
     val context = LocalContext.current
     val onboardingPrefs = remember { OnboardingPreferences(context) }
 
@@ -155,24 +155,19 @@ fun AppNavigation() {
         // ── Detalle de captura ────────────────────────────────────────────
         composable(Screen.CaptureDetail.route) {
             val capture = NavigationState.captureForDetail
+            val catalogViewModel: CatalogViewModel = hiltViewModel()
 
             if (capture != null) {
-                val scope = androidx.compose.runtime.rememberCoroutineScope()
-
                 CaptureDetailScreen(
                     capture        = capture,
                     onNavigateBack = { navController.popBackStack() },
                     onDelete = { id ->
-                        scope.launch {
-                            com.cetecom.ibichos.data.repository.CaptureRepositoryImpl().deleteCapture(id)
-                            navController.popBackStack()
-                        }
+                        catalogViewModel.deleteCapture(id)
+                        navController.popBackStack()
                     },
                     onAppeal = { id ->
-                        scope.launch {
-                            com.cetecom.ibichos.data.repository.CaptureRepositoryImpl().appealCapture(id)
-                            navController.popBackStack()
-                        }
+                        catalogViewModel.appealCapture(id)
+                        navController.popBackStack()
                     },
                     onNavigateToMap = { lat, lng ->
                         navController.navigate(Screen.Map.createRoute(lat, lng))
@@ -320,7 +315,7 @@ fun MainScreenWithBottomNav(
 
             composable("catalog") {
 
-                val catalogViewModel: CatalogViewModel = viewModel()
+                val catalogViewModel: CatalogViewModel = hiltViewModel()
 
                 CatalogScreen(
                     viewModel = catalogViewModel,

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/profile/ProfileScreen.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/profile/ProfileScreen.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import com.cetecom.ibichos.domain.model.enums.MedalInfo
 import com.cetecom.ibichos.ui.theme.*
@@ -49,7 +49,7 @@ private val SoftGreen = Color(0xFFEFFFF6)
 @Composable
 fun ProfileScreen(
     onLogout: () -> Unit,
-    viewModel: ProfileViewModel = viewModel()
+    viewModel: ProfileViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var selectedMedal by remember { mutableStateOf<MedalInfo?>(null) }

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/profile/ProfileViewModel.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/profile/ProfileViewModel.kt
@@ -1,25 +1,23 @@
 package com.cetecom.ibichos.presentation.profile
 
+import android.content.Context
 import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.cetecom.ibichos.data.repository.UserRepositoryImpl
 import com.cetecom.ibichos.domain.model.UserProfile
-import com.google.firebase.auth.FirebaseAuth
+import com.cetecom.ibichos.domain.repository.AuthRepository
+import com.cetecom.ibichos.domain.usecase.profile.GetUserProfileUseCase
+import com.cetecom.ibichos.domain.usecase.profile.UploadAvatarUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import android.content.Context
 import java.io.File
 import java.io.FileOutputStream
 import java.util.UUID
-import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.MultipartBody
-import okhttp3.RequestBody.Companion.asRequestBody
-import okhttp3.RequestBody.Companion.toRequestBody
-import com.cetecom.ibichos.data.repository.CloudinaryModule
+import javax.inject.Inject
 
 data class ProfileUiState(
     val profile: UserProfile? = null,
@@ -29,10 +27,12 @@ data class ProfileUiState(
     val successMessage: String? = null
 )
 
-class ProfileViewModel : ViewModel() {
-
-    private val auth       = FirebaseAuth.getInstance()
-    private val repository = UserRepositoryImpl()
+@HiltViewModel
+class ProfileViewModel @Inject constructor(
+    private val authRepository: AuthRepository,
+    private val getUserProfileUseCase: GetUserProfileUseCase,
+    private val uploadAvatarUseCase: UploadAvatarUseCase
+) : ViewModel() {
 
     private val _uiState = MutableStateFlow(ProfileUiState())
     val uiState: StateFlow<ProfileUiState> = _uiState.asStateFlow()
@@ -42,77 +42,48 @@ class ProfileViewModel : ViewModel() {
     }
 
     fun loadProfile() {
-        val uid = auth.currentUser?.uid ?: return
-
+        val uid = authRepository.getCurrentUserId() ?: return
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
-            try {
-                val profile = repository.getUserProfile(uid)
-                _uiState.update { it.copy(profile = profile, isLoading = false) }
-            } catch (e: Exception) {
-                _uiState.update {
-                    it.copy(isLoading = false, error = "Error al cargar perfil: ${e.message}")
+            runCatching { getUserProfileUseCase(uid) }
+                .onSuccess { profile ->
+                    _uiState.update { it.copy(profile = profile, isLoading = false) }
                 }
-            }
+                .onFailure { e ->
+                    _uiState.update { it.copy(isLoading = false, error = "Error al cargar perfil: ${e.message}") }
+                }
         }
     }
 
     fun uploadAvatar(uri: Uri, context: Context) {
-        val uid = auth.currentUser?.uid ?: return
-
+        val uid = authRepository.getCurrentUserId() ?: return
         viewModelScope.launch {
             _uiState.update { it.copy(isUploadingAvatar = true, error = null) }
-            try {
-                // 1. Copiar Uri a File temporal
-                val contentResolver = context.contentResolver
-                val inputStream = contentResolver.openInputStream(uri) 
+            runCatching {
+                // Copiar Uri a File temporal (operación Android-específica, permanece en el ViewModel)
+                val inputStream = context.contentResolver.openInputStream(uri)
                     ?: throw Exception("No se pudo abrir la imagen")
-                
-                val filename = UUID.randomUUID().toString() + ".jpg"
-                val tempFile = File(context.cacheDir, filename)
-                
-                FileOutputStream(tempFile).use { outputStream ->
-                    inputStream.copyTo(outputStream)
-                }
+                val tempFile = File(context.cacheDir, "${UUID.randomUUID()}.jpg")
+                FileOutputStream(tempFile).use { inputStream.copyTo(it) }
 
-                // 2. Subir a Cloudinary
-                val requestFile = tempFile.asRequestBody("image/*".toMediaType())
-                val filePart = MultipartBody.Part.createFormData("file", tempFile.name, requestFile)
-                val presetBody = "IBichos".toRequestBody("text/plain".toMediaType())
-
-                val cloudinaryResponse = CloudinaryModule.api.uploadImage(
-                    cloudName = "drubfka1z",
-                    file = filePart,
-                    uploadPreset = presetBody
-                )
-
-                val cloudinaryUrl = cloudinaryResponse.secure_url
-                    ?: throw Exception("Cloudinary no devolvió una URL válida")
-
-                // 3. Guardar la URL remota en Firestore
-                val finalUrl = repository.updateAvatar(uid, Uri.parse(cloudinaryUrl))
-                
-                _uiState.update { state ->
-                    state.copy(
-                        isUploadingAvatar = false,
-                        profile = state.profile?.copy(avatarUrl = finalUrl),
-                        successMessage = "¡Avatar actualizado en la nube!"
-                    )
-                }
-            } catch (e: Exception) {
-                _uiState.update {
-                    it.copy(isUploadingAvatar = false, error = "Error al subir foto: ${e.message}")
-                }
+                uploadAvatarUseCase(uid, tempFile)
             }
+                .onSuccess { url ->
+                    _uiState.update { state ->
+                        state.copy(
+                            isUploadingAvatar = false,
+                            profile = state.profile?.copy(avatarUrl = url),
+                            successMessage = "¡Avatar actualizado en la nube!"
+                        )
+                    }
+                }
+                .onFailure { e ->
+                    _uiState.update { it.copy(isUploadingAvatar = false, error = "Error al subir foto: ${e.message}") }
+                }
         }
     }
 
-    fun logout() {
-        auth.signOut()
-    }
+    fun logout() = authRepository.signOut()
 
-    fun clearMessages() {
-        _uiState.update { it.copy(error = null, successMessage = null) }
-    }
+    fun clearMessages() = _uiState.update { it.copy(error = null, successMessage = null) }
 }
-

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/ranking/RankingScreen.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/ranking/RankingScreen.kt
@@ -54,7 +54,7 @@ private val SoftGreenDark = Color(0xFF27AE60)
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RankingScreen(
-    viewModel: RankingViewModel = androidx.lifecycle.viewmodel.compose.viewModel()
+    viewModel: RankingViewModel = androidx.hilt.navigation.compose.hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
 

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/ranking/RankingViewModel.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/ranking/RankingViewModel.kt
@@ -2,19 +2,19 @@ package com.cetecom.ibichos.presentation.ranking
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.cetecom.ibichos.data.repository.UserRepositoryImpl
 import com.cetecom.ibichos.domain.model.UserProfile
-import com.cetecom.ibichos.domain.repository.UserRepository
+import com.cetecom.ibichos.domain.repository.AuthRepository
+import com.cetecom.ibichos.domain.usecase.profile.GetUserProfileUseCase
+import com.cetecom.ibichos.domain.usecase.ranking.GetRankingUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import com.google.firebase.auth.FirebaseAuth
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-enum class RankingType {
-    XP, UNIQUE, MEDALS
-}
+enum class RankingType { XP, UNIQUE, MEDALS }
 
 data class RankingUiState(
     val isLoading: Boolean = false,
@@ -26,11 +26,13 @@ data class RankingUiState(
     val currentUserRank: Int? = null
 )
 
-class RankingViewModel(
-    private val userRepository: UserRepository = UserRepositoryImpl()
+@HiltViewModel
+class RankingViewModel @Inject constructor(
+    private val authRepository: AuthRepository,
+    private val getRankingUseCase: GetRankingUseCase,
+    private val getUserProfileUseCase: GetUserProfileUseCase
 ) : ViewModel() {
 
-    private val auth = FirebaseAuth.getInstance()
     private val _uiState = MutableStateFlow(RankingUiState())
     val uiState: StateFlow<RankingUiState> = _uiState.asStateFlow()
 
@@ -41,37 +43,31 @@ class RankingViewModel(
     fun loadRanking(type: RankingType = _uiState.value.currentType) {
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null, currentType = type) }
-            try {
-                val currentUid = auth.currentUser?.uid
-                val currentProfile = if (currentUid != null) {
-                    try { userRepository.getUserProfile(currentUid) } catch (e: Exception) { null }
-                } else null
-
-                val topUsers = when (type) {
-                    RankingType.XP -> userRepository.getTopUsersByXp(50)
-                    RankingType.UNIQUE -> userRepository.getTopUsersByUniqueInsects(50)
-                    RankingType.MEDALS -> userRepository.getTopUsersByMedals(50)
+            val currentUid = authRepository.getCurrentUserId()
+            runCatching {
+                val currentProfile = currentUid?.let {
+                    runCatching { getUserProfileUseCase(it) }.getOrNull()
                 }
-                
-                val currentRank = if (currentUid != null) {
-                    val index = topUsers.indexOfFirst { it.uid == currentUid }
-                    if (index >= 0) index + 1 else null
-                } else null
-
-                _uiState.update { it.copy(
-                    isLoading = false, 
-                    users = topUsers,
-                    currentUserId = currentUid,
-                    currentUserProfile = currentProfile,
-                    currentUserRank = currentRank
-                ) }
-            } catch (e: Exception) {
-                _uiState.update { it.copy(
-                    isLoading = false,
-                    error = "Error al cargar el ranking: ${e.message}"
-                )}
+                val topUsers = getRankingUseCase(type)
+                val currentRank = currentUid?.let { uid ->
+                    topUsers.indexOfFirst { it.uid == uid }.takeIf { it >= 0 }?.plus(1)
+                }
+                Triple(topUsers, currentProfile, currentRank)
             }
+                .onSuccess { (topUsers, currentProfile, currentRank) ->
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            users = topUsers,
+                            currentUserId = currentUid,
+                            currentUserProfile = currentProfile,
+                            currentUserRank = currentRank
+                        )
+                    }
+                }
+                .onFailure { e ->
+                    _uiState.update { it.copy(isLoading = false, error = "Error al cargar el ranking: ${e.message}") }
+                }
         }
     }
 }
-

--- a/iBichos-app/build.gradle.kts
+++ b/iBichos-app/build.gradle.kts
@@ -2,6 +2,6 @@
 plugins {
     id("com.android.application") version "8.2.2" apply false
     id("org.jetbrains.kotlin.android") version "1.9.22" apply false
-    // Google services plugin para Firebase
     id("com.google.gms.google-services") version "4.4.0" apply false
+    id("com.google.dagger.hilt.android") version "2.48.1" apply false
 }


### PR DESCRIPTION
- Add Hilt 2.48.1 for dependency injection (AppModule, RepositoryModule)
- Create IBichosApplication with @HiltAndroidApp
- Extract AuthRepository interface + AuthRepositoryImpl (removes Firebase direct calls from ViewModel)
- Add @Inject constructors to all repository implementations
- Create 11 use cases across auth, capture, map, profile and ranking domains
- Extract ProcessCaptureUseCase with all gamification/moderation logic from CameraViewModel
- Annotate all 6 ViewModels with @HiltViewModel and inject use cases
- Unify MapViewModel from 3 separate StateFlows into a single MapUiState
- Replace viewModel() with hiltViewModel() across all screens and navigation
- Update UserRepository.updateAvatar signature to accept String instead of android.net.Uri
- Wire CaptureDetail actions through CatalogViewModel (eliminates direct repo instantiation)