### PR TITLE
feat: add ViewData, presentation mappers and Firestore write DTOs

### DIFF
--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/data/remote/dto/CaptureDocumentDto.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/data/remote/dto/CaptureDocumentDto.kt
@@ -1,0 +1,42 @@
+package com.cetecom.ibichos.data.remote.dto
+
+import com.google.firebase.Timestamp
+
+/**
+ * DTO de escritura para el documento de captura en Firestore.
+ *
+ * Centraliza los nombres de campo en un único lugar,
+ * eliminando los hashMapOf dispersos en el repositorio.
+ */
+data class CaptureDocumentDto(
+    val userId: String,
+    val imageUrl: String,
+    val insectName: String,
+    val scientificName: String,
+    val category: String,       // nombre del enum: "HYMENOPTERA"
+    val dangerLevel: String,    // nombre del enum: "CAUTION"
+    val probability: Double,
+    val latitude: Double?,
+    val longitude: Double?,
+    val xpAwarded: Long,
+    val description: String,
+    val needsReview: Boolean,
+    val status: String
+) {
+    fun toMap(): Map<String, Any?> = mapOf(
+        "userId"         to userId,
+        "imageUrl"       to imageUrl,
+        "insectName"     to insectName,
+        "scientificName" to scientificName,
+        "category"       to category,
+        "dangerLevel"    to dangerLevel,
+        "probability"    to probability,
+        "latitude"       to latitude,
+        "longitude"      to longitude,
+        "timestamp"      to Timestamp.now(),
+        "xpAwarded"      to xpAwarded,
+        "description"    to description,
+        "needsReview"    to needsReview,
+        "status"         to status
+    )
+}

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/data/remote/dto/UserDocumentDto.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/data/remote/dto/UserDocumentDto.kt
@@ -1,0 +1,49 @@
+package com.cetecom.ibichos.data.remote.dto
+
+import com.google.firebase.Timestamp
+
+/**
+ * DTO de escritura para el documento de usuario en Firestore.
+ *
+ * Se construye en el repositorio antes de hacer .set() o .update(),
+ * centralizando los nombres de campos en un solo lugar.
+ */
+data class UserDocumentDto(
+    val displayName: String,
+    val email: String,
+    val region: String,
+    val city: String,
+    val birthDate: String,
+    val gender: String,
+    val avatarUrl: String? = null
+) {
+    fun toNewUserMap(): Map<String, Any?> = mapOf(
+        "displayName"        to displayName,
+        "email"              to email,
+        "region"             to region,
+        "city"               to city,
+        "birthDate"          to birthDate,
+        "gender"             to gender,
+        "avatarUrl"          to avatarUrl,
+        "totalCaptures"      to 0,
+        "createdAt"          to Timestamp.now(),
+        "strikes"            to 0,
+        "isShadowBanned"     to false,
+        "xp"                 to 0L,
+        "uniqueInsectsCount" to 0,
+        "medalsCount"        to 0,
+        "gamification"       to initialGamificationMap()
+    )
+
+    companion object {
+        fun initialGamificationMap(): Map<String, Any> = mapOf(
+            "xp"                 to 0L,
+            "level"              to "CASUAL",
+            "uniqueInsectsCount" to 0,
+            "medals"             to emptyList<String>(),
+            "medalsEarnedAt"     to emptyMap<String, Long>(),
+            "categoryCounts"     to emptyMap<String, Int>(),
+            "levelUpAt"          to emptyMap<String, Long>()
+        )
+    }
+}

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/data/repository/AuthRepositoryImpl.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/data/repository/AuthRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package com.cetecom.ibichos.data.repository
 
+import com.cetecom.ibichos.data.remote.dto.UserDocumentDto
 import com.cetecom.ibichos.domain.repository.AuthRepository
-import com.google.firebase.Timestamp
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.GoogleAuthProvider
 import com.google.firebase.firestore.FirebaseFirestore
@@ -14,7 +14,6 @@ class AuthRepositoryImpl @Inject constructor(
 ) : AuthRepository {
 
     override fun isLoggedIn(): Boolean = auth.currentUser != null
-
     override fun getCurrentUserId(): String? = auth.currentUser?.uid
 
     override suspend fun login(email: String, password: String) {
@@ -33,33 +32,15 @@ class AuthRepositoryImpl @Inject constructor(
         val result = auth.createUserWithEmailAndPassword(email, password).await()
         val uid = result.user?.uid ?: throw IllegalStateException("UID nulo tras el registro")
 
-        db.collection("users").document(uid).set(
-            hashMapOf(
-                "displayName"        to displayName,
-                "email"              to email,
-                "region"             to region,
-                "city"               to city,
-                "birthDate"          to birthDate,
-                "gender"             to gender,
-                "avatarUrl"          to null,
-                "totalCaptures"      to 0,
-                "createdAt"          to Timestamp.now(),
-                "strikes"            to 0,
-                "isShadowBanned"     to false,
-                "xp"                 to 0L,
-                "uniqueInsectsCount" to 0,
-                "medalsCount"        to 0,
-                "gamification" to hashMapOf(
-                    "xp"                 to 0L,
-                    "level"              to "CASUAL",
-                    "uniqueInsectsCount" to 0,
-                    "medals"             to emptyList<String>(),
-                    "medalsEarnedAt"     to emptyMap<String, Long>(),
-                    "categoryCounts"     to emptyMap<String, Int>(),
-                    "levelUpAt"          to emptyMap<String, Long>()
-                )
-            )
-        ).await()
+        val dto = UserDocumentDto(
+            displayName = displayName,
+            email       = email,
+            region      = region,
+            city        = city,
+            birthDate   = birthDate,
+            gender      = gender
+        )
+        db.collection("users").document(uid).set(dto.toNewUserMap()).await()
 
         return uid
     }
@@ -71,61 +52,30 @@ class AuthRepositoryImpl @Inject constructor(
         val isNewUser = result.additionalUserInfo?.isNewUser == true
 
         if (isNewUser) {
-            db.collection("users").document(user.uid).set(
-                hashMapOf(
-                    "displayName"        to (user.displayName ?: "Cazador"),
-                    "email"              to (user.email ?: ""),
-                    "region"             to "",
-                    "city"               to "",
-                    "birthDate"          to "",
-                    "gender"             to "UNSPECIFIED",
-                    "avatarUrl"          to user.photoUrl?.toString(),
-                    "totalCaptures"      to 0,
-                    "createdAt"          to Timestamp.now(),
-                    "strikes"            to 0,
-                    "isShadowBanned"     to false,
-                    "xp"                 to 0L,
-                    "uniqueInsectsCount" to 0,
-                    "medalsCount"        to 0,
-                    "gamification"       to hashMapOf(
-                        "xp"                 to 0L,
-                        "level"              to "CASUAL",
-                        "uniqueInsectsCount" to 0,
-                        "medals"             to emptyList<String>(),
-                        "medalsEarnedAt"     to emptyMap<String, Long>(),
-                        "categoryCounts"     to emptyMap<String, Int>(),
-                        "levelUpAt"          to emptyMap<String, Long>()
-                    )
-                )
-            ).await()
+            val dto = UserDocumentDto(
+                displayName = user.displayName ?: "Cazador",
+                email       = user.email ?: "",
+                region      = "",
+                city        = "",
+                birthDate   = "",
+                gender      = "UNSPECIFIED",
+                avatarUrl   = user.photoUrl?.toString()
+            )
+            db.collection("users").document(user.uid).set(dto.toNewUserMap()).await()
         }
 
         return Pair(user.uid, isNewUser)
     }
 
-    override suspend fun completeProfile(
-        uid: String,
-        region: String,
-        city: String,
-        birthDate: String,
-        gender: String
-    ) {
+    override suspend fun completeProfile(uid: String, region: String, city: String, birthDate: String, gender: String) {
         db.collection("users").document(uid).update(
-            mapOf(
-                "region"    to region,
-                "city"      to city,
-                "birthDate" to birthDate,
-                "gender"    to gender
-            )
+            mapOf("region" to region, "city" to city, "birthDate" to birthDate, "gender" to gender)
         ).await()
     }
 
     override suspend fun checkProfileCompletion(uid: String): Boolean {
         val doc = db.collection("users").document(uid).get().await()
-        val region = doc.getString("region") ?: ""
-        val city = doc.getString("city") ?: ""
-        val birthDate = doc.getString("birthDate") ?: ""
-        return region.isNotEmpty() && city.isNotEmpty() && birthDate.isNotEmpty()
+        return listOf("region", "city", "birthDate").all { doc.getString(it)?.isNotEmpty() == true }
     }
 
     override suspend fun getLocations(): Map<String, List<String>> {
@@ -135,11 +85,6 @@ class AuthRepositoryImpl @Inject constructor(
         return (doc.get("regions") as? Map<String, List<String>>) ?: emptyMap()
     }
 
-    override fun signOut() {
-        auth.signOut()
-    }
-
-    override fun sendPasswordResetEmail(email: String) {
-        auth.sendPasswordResetEmail(email)
-    }
+    override fun signOut() = auth.signOut()
+    override fun sendPasswordResetEmail(email: String) { auth.sendPasswordResetEmail(email) }
 }

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/data/repository/CaptureRepositoryImpl.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/data/repository/CaptureRepositoryImpl.kt
@@ -1,11 +1,11 @@
 package com.cetecom.ibichos.data.repository
 
 import com.cetecom.ibichos.data.mapper.toCaptureItem
+import com.cetecom.ibichos.data.remote.dto.CaptureDocumentDto
 import com.cetecom.ibichos.domain.model.CaptureItem
 import com.cetecom.ibichos.domain.model.enums.DangerLevel
 import com.cetecom.ibichos.domain.model.enums.InsectCategory
 import com.cetecom.ibichos.domain.repository.CaptureRepository
-import com.google.firebase.Timestamp
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.Query
 import kotlinx.coroutines.tasks.await
@@ -15,27 +15,21 @@ class CaptureRepositoryImpl @Inject constructor(
     private val db: FirebaseFirestore
 ) : CaptureRepository {
 
-    override suspend fun getCaptures(userId: String): List<CaptureItem> {
-        return db.collection("captures")
+    override suspend fun getCaptures(userId: String): List<CaptureItem> =
+        db.collection("captures")
             .whereEqualTo("userId", userId)
-            .get()
-            .await()
-            .documents
+            .get().await().documents
             .map { it.toCaptureItem() }
             .filter { it.status != "DELETED" }
             .sortedByDescending { it.capturedAt }
-    }
 
-    override suspend fun getGlobalCaptures(limit: Int): List<CaptureItem> {
-        return db.collection("captures")
+    override suspend fun getGlobalCaptures(limit: Int): List<CaptureItem> =
+        db.collection("captures")
             .orderBy("timestamp", Query.Direction.DESCENDING)
             .limit(limit.toLong())
-            .get()
-            .await()
-            .documents
+            .get().await().documents
             .map { it.toCaptureItem() }
             .filter { it.status != "DELETED" }
-    }
 
     override suspend fun saveCapture(
         userId: String,
@@ -52,43 +46,36 @@ class CaptureRepositoryImpl @Inject constructor(
         needsReview: Boolean,
         status: String
     ): String {
-        val captureData = hashMapOf(
-            "userId"         to userId,
-            "imageUrl"       to imageUrl,
-            "insectName"     to insectName,
-            "scientificName" to scientificName,
-            "category"       to category.name,
-            "dangerLevel"    to dangerLevel.name,
-            "probability"    to probability,
-            "latitude"       to latitude,
-            "longitude"      to longitude,
-            "timestamp"      to Timestamp.now(),
-            "xpAwarded"      to xpAwarded,
-            "description"    to description,
-            "needsReview"    to needsReview,
-            "status"         to status
+        val dto = CaptureDocumentDto(
+            userId         = userId,
+            imageUrl       = imageUrl,
+            insectName     = insectName,
+            scientificName = scientificName,
+            category       = category.name,
+            dangerLevel    = dangerLevel.name,
+            probability    = probability,
+            latitude       = latitude,
+            longitude      = longitude,
+            xpAwarded      = xpAwarded,
+            description    = description,
+            needsReview    = needsReview,
+            status         = status
         )
-        return db.collection("captures").add(captureData).await().id
+        return db.collection("captures").add(dto.toMap()).await().id
     }
 
-    override suspend fun hasCaughtInsect(userId: String, scientificName: String): Boolean {
-        return db.collection("captures")
+    override suspend fun hasCaughtInsect(userId: String, scientificName: String): Boolean =
+        db.collection("captures")
             .whereEqualTo("userId", userId)
             .whereEqualTo("scientificName", scientificName)
-            .limit(1)
-            .get()
-            .await()
-            .isEmpty
-            .not()
-    }
+            .limit(1).get().await().isEmpty.not()
 
     override suspend fun deleteCapture(id: String) {
         db.collection("captures").document(id).update("status", "DELETED").await()
     }
 
     override suspend fun appealCapture(id: String) {
-        db.collection("captures").document(id).update(
-            mapOf("status" to "PENDING_REVIEW", "needsReview" to true)
-        ).await()
+        db.collection("captures").document(id)
+            .update(mapOf("status" to "PENDING_REVIEW", "needsReview" to true)).await()
     }
 }

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/catalog/CatalogViewModel.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/catalog/CatalogViewModel.kt
@@ -2,11 +2,12 @@ package com.cetecom.ibichos.presentation.catalog
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.cetecom.ibichos.domain.model.CaptureItem
 import com.cetecom.ibichos.domain.repository.AuthRepository
 import com.cetecom.ibichos.domain.repository.CaptureRepository
 import com.cetecom.ibichos.domain.usecase.capture.DeleteCaptureUseCase
 import com.cetecom.ibichos.domain.usecase.capture.GetCapturesUseCase
+import com.cetecom.ibichos.presentation.catalog.mapper.toViewDataList
+import com.cetecom.ibichos.presentation.catalog.viewdata.CaptureViewData
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -16,7 +17,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 data class CatalogUiState(
-    val captures: List<CaptureItem> = emptyList(),
+    val captures: List<CaptureViewData> = emptyList(),
     val isLoading: Boolean = false,
     val error: String? = null
 )
@@ -32,9 +33,7 @@ class CatalogViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(CatalogUiState())
     val uiState: StateFlow<CatalogUiState> = _uiState.asStateFlow()
 
-    init {
-        loadCaptures()
-    }
+    init { loadCaptures() }
 
     fun loadCaptures() {
         val uid = authRepository.getCurrentUserId() ?: return
@@ -42,7 +41,7 @@ class CatalogViewModel @Inject constructor(
             _uiState.update { it.copy(isLoading = true, error = null) }
             runCatching { getCapturesUseCase(uid) }
                 .onSuccess { captures ->
-                    _uiState.update { it.copy(captures = captures, isLoading = false) }
+                    _uiState.update { it.copy(captures = captures.toViewDataList(), isLoading = false) }
                 }
                 .onFailure { e ->
                     _uiState.update { it.copy(isLoading = false, error = "Error al cargar capturas: ${e.message}") }
@@ -54,9 +53,7 @@ class CatalogViewModel @Inject constructor(
         viewModelScope.launch {
             runCatching { deleteCaptureUseCase(id) }
                 .onSuccess { loadCaptures() }
-                .onFailure { e ->
-                    _uiState.update { it.copy(error = "No se pudo eliminar: ${e.message}") }
-                }
+                .onFailure { e -> _uiState.update { it.copy(error = "No se pudo eliminar: ${e.message}") } }
         }
     }
 
@@ -64,9 +61,7 @@ class CatalogViewModel @Inject constructor(
         viewModelScope.launch {
             runCatching { captureRepository.appealCapture(id) }
                 .onSuccess { loadCaptures() }
-                .onFailure { e ->
-                    _uiState.update { it.copy(error = "No se pudo apelar: ${e.message}") }
-                }
+                .onFailure { e -> _uiState.update { it.copy(error = "No se pudo apelar: ${e.message}") } }
         }
     }
 }

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/catalog/mapper/CaptureViewDataMapper.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/catalog/mapper/CaptureViewDataMapper.kt
@@ -1,0 +1,29 @@
+package com.cetecom.ibichos.presentation.catalog.mapper
+
+import com.cetecom.ibichos.domain.model.CaptureItem
+import com.cetecom.ibichos.presentation.catalog.viewdata.CaptureViewData
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+fun CaptureItem.toViewData(): CaptureViewData = CaptureViewData(
+    id                   = id,
+    imageUrl             = imageUrl,
+    insectName           = insectName,
+    scientificName       = scientificName,
+    categoryLabel        = category.displayName(),
+    dangerLabel          = dangerLevel.displayName(),
+    probabilityFormatted = "${(probability * 100).toInt()}%",
+    dateFormatted        = capturedAt.toFormattedDate(),
+    xpAwarded            = xpAwarded,
+    description          = description,
+    status               = status,
+    needsReview          = needsReview,
+    latitude             = latitude,
+    longitude            = longitude
+)
+
+fun List<CaptureItem>.toViewDataList(): List<CaptureViewData> = map { it.toViewData() }
+
+private fun Long.toFormattedDate(): String =
+    SimpleDateFormat("d MMM yyyy", Locale("es")).format(Date(this))

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/catalog/viewdata/CaptureViewData.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/catalog/viewdata/CaptureViewData.kt
@@ -1,0 +1,24 @@
+package com.cetecom.ibichos.presentation.catalog.viewdata
+
+/**
+ * Modelo de UI para una captura — listo para renderizar, sin lógica de formato en la pantalla.
+ *
+ * Las conversiones (enum → label, Long → fecha, Double → %) ocurren en el mapper,
+ * no en el Composable.
+ */
+data class CaptureViewData(
+    val id: String,
+    val imageUrl: String,
+    val insectName: String,
+    val scientificName: String,
+    val categoryLabel: String,          // "Arácnido", "Himenóptero"…
+    val dangerLabel: String,            // "Venenoso 🔴", "Inofensivo 🟢"…
+    val probabilityFormatted: String,   // "94%"
+    val dateFormatted: String,          // "12 may 2026"
+    val xpAwarded: Long,
+    val description: String,
+    val status: String,                 // "APPROVED", "PENDING_REVIEW", "DELETED"
+    val needsReview: Boolean,
+    val latitude: Double?,
+    val longitude: Double?
+)

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/map/MapViewModel.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/map/MapViewModel.kt
@@ -2,9 +2,10 @@ package com.cetecom.ibichos.presentation.map
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.cetecom.ibichos.domain.model.CaptureItem
 import com.cetecom.ibichos.domain.repository.AuthRepository
 import com.cetecom.ibichos.domain.usecase.map.GetMapCapturesUseCase
+import com.cetecom.ibichos.presentation.map.mapper.toMapViewDataList
+import com.cetecom.ibichos.presentation.map.viewdata.MapCaptureViewData
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -14,7 +15,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 data class MapUiState(
-    val captures: List<CaptureItem> = emptyList(),
+    val captures: List<MapCaptureViewData> = emptyList(),
     val isLoading: Boolean = false,
     val isGlobalMap: Boolean = false,
     val error: String? = null
@@ -29,9 +30,7 @@ class MapViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(MapUiState())
     val uiState: StateFlow<MapUiState> = _uiState.asStateFlow()
 
-    init {
-        loadCaptures()
-    }
+    init { loadCaptures() }
 
     fun setGlobalMode(isGlobal: Boolean) {
         if (_uiState.value.isGlobalMap == isGlobal) return
@@ -45,7 +44,7 @@ class MapViewModel @Inject constructor(
             _uiState.update { it.copy(isLoading = true, error = null) }
             runCatching { getMapCapturesUseCase(uid, _uiState.value.isGlobalMap) }
                 .onSuccess { captures ->
-                    _uiState.update { it.copy(captures = captures, isLoading = false) }
+                    _uiState.update { it.copy(captures = captures.toMapViewDataList(), isLoading = false) }
                 }
                 .onFailure {
                     _uiState.update { it.copy(isLoading = false) }

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/map/mapper/MapCaptureViewDataMapper.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/map/mapper/MapCaptureViewDataMapper.kt
@@ -1,0 +1,20 @@
+package com.cetecom.ibichos.presentation.map.mapper
+
+import com.cetecom.ibichos.domain.model.CaptureItem
+import com.cetecom.ibichos.presentation.map.viewdata.MapCaptureViewData
+
+fun CaptureItem.toMapViewData(): MapCaptureViewData? {
+    val lat = latitude ?: return null
+    val lon = longitude ?: return null
+    return MapCaptureViewData(
+        id            = id,
+        imageUrl      = imageUrl,
+        insectName    = insectName,
+        categoryLabel = category.displayName(),
+        latitude      = lat,
+        longitude     = lon
+    )
+}
+
+fun List<CaptureItem>.toMapViewDataList(): List<MapCaptureViewData> =
+    mapNotNull { it.toMapViewData() }

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/map/viewdata/MapCaptureViewData.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/map/viewdata/MapCaptureViewData.kt
@@ -1,0 +1,16 @@
+package com.cetecom.ibichos.presentation.map.viewdata
+
+/**
+ * Modelo de UI para un pin en el mapa.
+ *
+ * Solo contiene los campos necesarios para renderizar el marcador y su popup.
+ * Se excluyen campos como description, xpAwarded, status, etc. que el mapa no usa.
+ */
+data class MapCaptureViewData(
+    val id: String,
+    val imageUrl: String,
+    val insectName: String,
+    val categoryLabel: String,  // "Arácnido", "Himenóptero"…
+    val latitude: Double,
+    val longitude: Double
+)

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/profile/ProfileViewModel.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/profile/ProfileViewModel.kt
@@ -4,10 +4,11 @@ import android.content.Context
 import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.cetecom.ibichos.domain.model.UserProfile
 import com.cetecom.ibichos.domain.repository.AuthRepository
 import com.cetecom.ibichos.domain.usecase.profile.GetUserProfileUseCase
 import com.cetecom.ibichos.domain.usecase.profile.UploadAvatarUseCase
+import com.cetecom.ibichos.presentation.profile.mapper.toViewData
+import com.cetecom.ibichos.presentation.profile.viewdata.UserProfileViewData
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -20,7 +21,7 @@ import java.util.UUID
 import javax.inject.Inject
 
 data class ProfileUiState(
-    val profile: UserProfile? = null,
+    val profile: UserProfileViewData? = null,
     val isLoading: Boolean = false,
     val isUploadingAvatar: Boolean = false,
     val error: String? = null,
@@ -37,9 +38,7 @@ class ProfileViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(ProfileUiState())
     val uiState: StateFlow<ProfileUiState> = _uiState.asStateFlow()
 
-    init {
-        loadProfile()
-    }
+    init { loadProfile() }
 
     fun loadProfile() {
         val uid = authRepository.getCurrentUserId() ?: return
@@ -47,7 +46,7 @@ class ProfileViewModel @Inject constructor(
             _uiState.update { it.copy(isLoading = true, error = null) }
             runCatching { getUserProfileUseCase(uid) }
                 .onSuccess { profile ->
-                    _uiState.update { it.copy(profile = profile, isLoading = false) }
+                    _uiState.update { it.copy(profile = profile.toViewData(), isLoading = false) }
                 }
                 .onFailure { e ->
                     _uiState.update { it.copy(isLoading = false, error = "Error al cargar perfil: ${e.message}") }
@@ -60,12 +59,10 @@ class ProfileViewModel @Inject constructor(
         viewModelScope.launch {
             _uiState.update { it.copy(isUploadingAvatar = true, error = null) }
             runCatching {
-                // Copiar Uri a File temporal (operación Android-específica, permanece en el ViewModel)
                 val inputStream = context.contentResolver.openInputStream(uri)
                     ?: throw Exception("No se pudo abrir la imagen")
                 val tempFile = File(context.cacheDir, "${UUID.randomUUID()}.jpg")
                 FileOutputStream(tempFile).use { inputStream.copyTo(it) }
-
                 uploadAvatarUseCase(uid, tempFile)
             }
                 .onSuccess { url ->
@@ -84,6 +81,5 @@ class ProfileViewModel @Inject constructor(
     }
 
     fun logout() = authRepository.signOut()
-
     fun clearMessages() = _uiState.update { it.copy(error = null, successMessage = null) }
 }

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/profile/mapper/UserProfileViewDataMapper.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/profile/mapper/UserProfileViewDataMapper.kt
@@ -1,0 +1,22 @@
+package com.cetecom.ibichos.presentation.profile.mapper
+
+import com.cetecom.ibichos.domain.model.UserProfile
+import com.cetecom.ibichos.presentation.profile.viewdata.UserProfileViewData
+import java.util.Locale
+
+fun UserProfile.toViewData(): UserProfileViewData = UserProfileViewData(
+    uid                 = uid,
+    displayName         = displayName,
+    avatarUrl           = avatarUrl,
+    region              = region,
+    city                = city,
+    xpFormatted         = gamification.xp.toFormattedXp(),
+    levelLabel          = gamification.level.displayName(),
+    medalsCount         = gamification.medals.size,
+    uniqueInsectsCount  = gamification.uniqueInsectsCount,
+    totalCaptures       = totalCaptures,
+    isShadowBanned      = isShadowBanned
+)
+
+private fun Long.toFormattedXp(): String =
+    String.format(Locale("es"), "%,d XP", this).replace(',', '.')

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/profile/viewdata/UserProfileViewData.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/profile/viewdata/UserProfileViewData.kt
@@ -1,0 +1,21 @@
+package com.cetecom.ibichos.presentation.profile.viewdata
+
+/**
+ * Modelo de UI para el perfil del usuario.
+ *
+ * Expone solo lo que la pantalla necesita mostrar,
+ * con valores ya formateados para no contaminar los Composables con lógica.
+ */
+data class UserProfileViewData(
+    val uid: String,
+    val displayName: String,
+    val avatarUrl: String?,
+    val region: String,
+    val city: String,
+    val xpFormatted: String,            // "1.200 XP"
+    val levelLabel: String,             // "Explorador"
+    val medalsCount: Int,
+    val uniqueInsectsCount: Int,
+    val totalCaptures: Int,
+    val isShadowBanned: Boolean
+)

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/ranking/RankingViewModel.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/ranking/RankingViewModel.kt
@@ -2,10 +2,11 @@ package com.cetecom.ibichos.presentation.ranking
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.cetecom.ibichos.domain.model.UserProfile
 import com.cetecom.ibichos.domain.repository.AuthRepository
 import com.cetecom.ibichos.domain.usecase.profile.GetUserProfileUseCase
 import com.cetecom.ibichos.domain.usecase.ranking.GetRankingUseCase
+import com.cetecom.ibichos.presentation.ranking.mapper.toRankingViewData
+import com.cetecom.ibichos.presentation.ranking.viewdata.RankingItemViewData
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -18,12 +19,10 @@ enum class RankingType { XP, UNIQUE, MEDALS }
 
 data class RankingUiState(
     val isLoading: Boolean = false,
-    val users: List<UserProfile> = emptyList(),
-    val error: String? = null,
+    val items: List<RankingItemViewData> = emptyList(),
     val currentType: RankingType = RankingType.XP,
-    val currentUserId: String? = null,
-    val currentUserProfile: UserProfile? = null,
-    val currentUserRank: Int? = null
+    val currentUserRank: Int? = null,
+    val error: String? = null
 )
 
 @HiltViewModel
@@ -36,33 +35,18 @@ class RankingViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(RankingUiState())
     val uiState: StateFlow<RankingUiState> = _uiState.asStateFlow()
 
-    init {
-        loadRanking(RankingType.XP)
-    }
+    init { loadRanking(RankingType.XP) }
 
     fun loadRanking(type: RankingType = _uiState.value.currentType) {
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null, currentType = type) }
             val currentUid = authRepository.getCurrentUserId()
-            runCatching {
-                val currentProfile = currentUid?.let {
-                    runCatching { getUserProfileUseCase(it) }.getOrNull()
-                }
-                val topUsers = getRankingUseCase(type)
-                val currentRank = currentUid?.let { uid ->
-                    topUsers.indexOfFirst { it.uid == uid }.takeIf { it >= 0 }?.plus(1)
-                }
-                Triple(topUsers, currentProfile, currentRank)
-            }
-                .onSuccess { (topUsers, currentProfile, currentRank) ->
+            runCatching { getRankingUseCase(type) }
+                .onSuccess { topUsers ->
+                    val items = topUsers.toRankingViewData(type, currentUid)
+                    val currentUserRank = items.firstOrNull { it.isCurrentUser }?.rank
                     _uiState.update {
-                        it.copy(
-                            isLoading = false,
-                            users = topUsers,
-                            currentUserId = currentUid,
-                            currentUserProfile = currentProfile,
-                            currentUserRank = currentRank
-                        )
+                        it.copy(isLoading = false, items = items, currentUserRank = currentUserRank)
                     }
                 }
                 .onFailure { e ->

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/ranking/mapper/RankingViewDataMapper.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/ranking/mapper/RankingViewDataMapper.kt
@@ -1,0 +1,26 @@
+package com.cetecom.ibichos.presentation.ranking.mapper
+
+import com.cetecom.ibichos.domain.model.UserProfile
+import com.cetecom.ibichos.presentation.ranking.RankingType
+import com.cetecom.ibichos.presentation.ranking.viewdata.RankingItemViewData
+import java.util.Locale
+
+fun List<UserProfile>.toRankingViewData(
+    type: RankingType,
+    currentUserId: String?
+): List<RankingItemViewData> = mapIndexed { index, profile ->
+    RankingItemViewData(
+        rank           = index + 1,
+        uid            = profile.uid,
+        displayName    = profile.displayName,
+        avatarUrl      = profile.avatarUrl,
+        valueFormatted = profile.formatValue(type),
+        isCurrentUser  = profile.uid == currentUserId
+    )
+}
+
+private fun UserProfile.formatValue(type: RankingType): String = when (type) {
+    RankingType.XP     -> String.format(Locale("es"), "%,d XP", gamification.xp).replace(',', '.')
+    RankingType.UNIQUE -> "${gamification.uniqueInsectsCount} especies"
+    RankingType.MEDALS -> "${gamification.medals.size} medallas"
+}

--- a/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/ranking/viewdata/RankingItemViewData.kt
+++ b/iBichos-app/app/src/main/java/com/cetecom/ibichos/presentation/ranking/viewdata/RankingItemViewData.kt
@@ -1,0 +1,18 @@
+package com.cetecom.ibichos.presentation.ranking.viewdata
+
+/**
+ * Modelo de UI para un ítem del ranking.
+ *
+ * [valueFormatted] cambia según el tipo de ranking activo:
+ *   - XP      → "1.200 XP"
+ *   - UNIQUE  → "12 especies"
+ *   - MEDALS  → "5 medallas"
+ */
+data class RankingItemViewData(
+    val rank: Int,
+    val uid: String,
+    val displayName: String,
+    val avatarUrl: String?,
+    val valueFormatted: String,
+    val isCurrentUser: Boolean
+)


### PR DESCRIPTION
- ViewData: CaptureViewData, UserProfileViewData, RankingItemViewData, MapCaptureViewData
- Presentation mappers: domain model -> ViewData with pre-formatted fields (dates, XP, %, labels)
- Firestore write DTOs: UserDocumentDto and CaptureDocumentDto replace raw hashMapOf()
- ViewModels: UiState now holds ViewData instead of domain models
- RankingViewModel simplified: currentUserRank derived from items, not separate profile query